### PR TITLE
Add support for specifying a Test and Production API key

### DIFF
--- a/Sources/Stripe/API/StripeRequest.swift
+++ b/Sources/Stripe/API/StripeRequest.swift
@@ -70,6 +70,7 @@ public class StripeAPIRequest: StripeRequest {
         
         headers.forEach { finalHeaders.add(name: $0.name, value: $0.value) }
         
+        // Get the appropiate API key based on the environment and if the test key is present
         let apiKey = self.httpClient.container.environment == .development ? (self.testApiKey ?? self.apiKey) : self.apiKey
         finalHeaders.add(name: .authorization, value: "Bearer \(apiKey)")
         

--- a/Sources/Stripe/API/StripeRequest.swift
+++ b/Sources/Stripe/API/StripeRequest.swift
@@ -55,10 +55,12 @@ extension HTTPHeaders {
 public class StripeAPIRequest: StripeRequest {
     private let httpClient: Client
     private let apiKey: String
+    private let testApiKey: String?
     
-    init(httpClient: Client, apiKey: String) {
+    init(httpClient: Client, apiKey: String, testApiKey: String?) {
         self.httpClient = httpClient
         self.apiKey = apiKey
+        self.testApiKey = testApiKey
     }
     
     public func send<SM: StripeModel>(method: HTTPMethod, path: String, query: String, body: String, headers: HTTPHeaders) throws -> Future<SM> {
@@ -68,6 +70,7 @@ public class StripeAPIRequest: StripeRequest {
         
         headers.forEach { finalHeaders.add(name: $0.name, value: $0.value) }
         
+        let apiKey = self.httpClient.container.environment == .development ? (self.testApiKey ?? self.apiKey) : self.apiKey
         finalHeaders.add(name: .authorization, value: "Bearer \(apiKey)")
         
         let request = HTTPRequest(method: method, url: URL(string: "\(path)?\(query)") ?? .root, headers: finalHeaders, body: encodedHTTPBody)

--- a/Sources/Stripe/API/StripeRequest.swift
+++ b/Sources/Stripe/API/StripeRequest.swift
@@ -39,7 +39,7 @@ extension HTTPHeaderName {
         return .init("Stripe-Version")
     }
     public static var stripeAccount: HTTPHeaderName {
-        return .init("Stripe-Version")
+        return .init("Stripe-Account")
     }
 }
 

--- a/Sources/Stripe/Provider/Provider.swift
+++ b/Sources/Stripe/Provider/Provider.swift
@@ -10,16 +10,25 @@ import Vapor
 
 public struct StripeConfig: Service {
     public let apiKey: String
+    public let testApiKey: String?
+
     public init(apiKey: String) {
         self.apiKey = apiKey
+        self.testApiKey = nil
+    }
+    
+    public init(productionKey: String, testKey: String) {
+        self.apiKey = productionKey
+        self.testApiKey = testKey
     }
 }
 
 public final class StripeProvider: Provider {
     public static let repositoryName = "stripe-provider"
     
-    public init(){}
-    public func boot(_ worker: Container) throws {}
+    public init() { }
+    
+    public func boot(_ worker: Container) throws { }
     
     public func didBoot(_ worker: Container) throws -> EventLoopFuture<Void> {
         return .done(on: worker)
@@ -29,7 +38,7 @@ public final class StripeProvider: Provider {
         services.register { (container) -> StripeClient in
             let httpClient = try container.make(Client.self)
             let config = try container.make(StripeConfig.self)
-            return StripeClient(apiKey: config.apiKey, client: httpClient)
+            return StripeClient(apiKey: config.apiKey, testKey: config.testApiKey, client: httpClient)
         }
     }
 }
@@ -57,8 +66,8 @@ public struct StripeClient: Service {
     public var transfer: StripeTransferRoutes
     public var transferReversals: StripeTransferReversalRoutes
 
-    internal init(apiKey: String, client: Client) {
-        let apiRequest = StripeAPIRequest(httpClient: client, apiKey: apiKey)
+    internal init(apiKey: String, testKey: String?, client: Client) {
+        let apiRequest = StripeAPIRequest(httpClient: client, apiKey: apiKey, testApiKey: testKey)
         
         balance = StripeBalanceRoutes(request: apiRequest)
         charge = StripeChargeRoutes(request: apiRequest)


### PR DESCRIPTION
Added an additional `StripeConfig` init to allow for specifying both the production and test API keys. 

`StripeConfig(productionKey: "", testKey: "")`

The test key will be used (if it's specified) when the environment is `development` 