### PR TITLE
Possibility to set custom API version in EphemeralKeyRoutes

### DIFF
--- a/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
+++ b/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
@@ -11,7 +11,7 @@ import Vapor
 public protocol EphemeralKeyRoutes {
     associatedtype EK: EphemeralKey
     
-    func create(customer: String) throws -> Future<EK>
+    func create(customer: String, apiVersion: String) throws -> Future<EK>
     func delete(ephemeralKey: String) throws -> Future<EK>
 }
 

--- a/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
+++ b/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
@@ -22,8 +22,8 @@ public struct StripeEphemeralKeyRoutes: EphemeralKeyRoutes {
         self.request = request
     }
     
-    public func create(customer: String) throws -> Future<StripeEphemeralKey> {
-        let body = ["customer": customer]
+    public func create(customer: String, apiVersion: String) throws -> Future<StripeEphemeralKey> {
+        let body = ["customer": customer, "stripe_version": apiVersion]
         return try request.send(method: .POST, path: StripeAPIEndpoint.ephemeralKeys.endpoint, body: body.queryParameters)
     }
     

--- a/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
+++ b/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
@@ -11,7 +11,7 @@ import Vapor
 public protocol EphemeralKeyRoutes {
     associatedtype EK: EphemeralKey
     
-    func create(customer: String, apiVersion: String) throws -> Future<EK>
+    func create(customer: String, apiVersion: String?) throws -> Future<EK>
     func delete(ephemeralKey: String) throws -> Future<EK>
 }
 
@@ -22,9 +22,12 @@ public struct StripeEphemeralKeyRoutes: EphemeralKeyRoutes {
         self.request = request
     }
     
-    public func create(customer: String, apiVersion: String) throws -> Future<StripeEphemeralKey> {
-		var headers = HTTPHeaders()
-		headers.add(name: "stripe_version", value: apiVersion)
+    public func create(customer: String, apiVersion: String? = nil) throws -> Future<StripeEphemeralKey> {
+		var headers: HTTPHeaders = [:]
+		
+		if let otherApiVersion = apiVersion {
+			headers.replaceOrAdd(name: .stripeVersion, value: otherApiVersion)
+		}
 		
 		let body = ["customer": customer]
 		return try request.send(method: .POST, path: StripeAPIEndpoint.ephemeralKeys.endpoint, body: body.queryParameters, headers: headers)

--- a/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
+++ b/Sources/Stripe/API/Routes/EphemeralKeyRoutes.swift
@@ -23,8 +23,11 @@ public struct StripeEphemeralKeyRoutes: EphemeralKeyRoutes {
     }
     
     public func create(customer: String, apiVersion: String) throws -> Future<StripeEphemeralKey> {
-        let body = ["customer": customer, "stripe_version": apiVersion]
-        return try request.send(method: .POST, path: StripeAPIEndpoint.ephemeralKeys.endpoint, body: body.queryParameters)
+		var headers = HTTPHeaders()
+		headers.add(name: "stripe_version", value: apiVersion)
+		
+		let body = ["customer": customer]
+		return try request.send(method: .POST, path: StripeAPIEndpoint.ephemeralKeys.endpoint, body: body.queryParameters, headers: headers)
     }
     
     public func delete(ephemeralKey: String) throws -> Future<StripeEphemeralKey> {

--- a/Sources/Stripe/API/StripeRequest.swift
+++ b/Sources/Stripe/API/StripeRequest.swift
@@ -66,7 +66,9 @@ public class StripeAPIRequest: StripeRequest {
     public func send<SM: StripeModel>(method: HTTPMethod, path: String, query: String, body: String, headers: HTTPHeaders) throws -> Future<SM> {
         var finalHeaders: HTTPHeaders = .stripeDefault
         
-        headers.forEach { finalHeaders.add(name: $0.name, value: $0.value) }
+        headers.forEach {
+			finalHeaders.replaceOrAdd(name: $0.name, value: $0.value)
+		}
         
         // Get the appropiate API key based on the environment and if the test key is present
         let apiKey = self.httpClient.container.environment == .development ? (self.testApiKey ?? self.apiKey) : self.apiKey


### PR DESCRIPTION
Custom API version in that request is required to be implemented, because `ephermalKeys.create` is sent by mobile application which API version may differ from framework's one.

E.g. iOS application may have _2015-01-01_ api version and it will need to receive reply using that api version from Stripe, framework just proxies reply from Stripe to iOS app without actual processing.

Custom API version for that request is implemented in all Stripe-powered frameworks like [stripe-php/.../EphermalKey.php](https://github.com/stripe/stripe-php/blob/67fee13fcb344aa865076589888f4afef542dfd7/lib/EphemeralKey.php#L45-L51)