### PR TITLE
Add support for tiers and usage transform to StripePlan

### DIFF
--- a/Sources/Stripe/Models/Plans/BillingScheme.swift
+++ b/Sources/Stripe/Models/Plans/BillingScheme.swift
@@ -7,17 +7,45 @@
 
 import Foundation
 
-public enum BillingScheme: String, Codable {
-    case perUnit = "per_unit"
-    case tiered
-}
-
-public enum TiersMode: String, Codable {
-    case graduated
-    case volume
-}
-
-public enum PlanUsageType: String, Codable {
-    case metered
-    case licensed
+extension StripePlan {
+    
+    public enum BillingScheme: String, Codable {
+        case perUnit = "per_unit"
+        case tiered
+    }
+    
+    public enum RoundMode: String, Codable {
+        case up
+        case down
+    }
+    
+    public struct Tier: Codable {
+        var amount: Int
+        var upTo: Int?
+        
+        public enum CodingKeys: String, CodingKey {
+            case amount
+            case upTo = "up_to"
+        }
+    }
+    
+    public enum TiersMode: String, Codable {
+        case graduated
+        case volume
+    }
+    
+    public struct UsageTransformation: Codable {
+        var divideBy: Int
+        var round: RoundMode
+        
+        public enum CodingKeys: String, CodingKey {
+            case divideBy = "divide_by"
+            case round
+        }
+    }
+    
+    public enum UsageType: String, Codable {
+        case metered
+        case licensed
+    }
 }

--- a/Sources/Stripe/Models/Plans/Plans.swift
+++ b/Sources/Stripe/Models/Plans/Plans.swift
@@ -18,7 +18,7 @@ public struct StripePlan: StripeModel {
     public var object: String
     public var active: Bool
     public var aggregateUsage: String?
-    public var amount: Int
+    public var amount: Int?
     public var billingScheme: BillingScheme
     public var created: Date
     public var currency: StripeCurrency
@@ -28,11 +28,11 @@ public struct StripePlan: StripeModel {
     public var metadata: [String: String]
     public var nickname: String?
     public var product: String
-    public var tiers: [String: Int]?
+    public var tiers: [Tier]?
     public var tiersMode: TiersMode?
-    public var transformUsage: [String: Int]?
+    public var transformUsage: UsageTransformation?
     public var trialPeriodDays: Int?
-    public var usageType: PlanUsageType
+    public var usageType: UsageType
     
     public enum CodingKeys: String, CodingKey {
         case id

--- a/Tests/StripeTests/SubscriptionTests.swift
+++ b/Tests/StripeTests/SubscriptionTests.swift
@@ -79,7 +79,18 @@ class SubscriptionTests: XCTestCase {
                 XCTAssertEqual(sub.items.data[0].plan.metadata["hello"], "world")
                 XCTAssertEqual(sub.items.data[0].plan.nickname, "Foo")
                 XCTAssertEqual(sub.items.data[0].plan.product, "prod_1234")
+                XCTAssertEqual(sub.items.data[0].plan.transformUsage?.divideBy, 5)
+                XCTAssertEqual(sub.items.data[0].plan.transformUsage?.round, .up)
                 XCTAssertEqual(sub.items.data[0].plan.trialPeriodDays, 3)
+
+                // These cover the Plan object
+                XCTAssertNotNil(sub.items.data[1].plan)
+                XCTAssertEqual(sub.items.data[1].plan.amount, nil)
+                XCTAssertEqual(sub.items.data[1].plan.tiers?[0].amount, 0)
+                XCTAssertEqual(sub.items.data[1].plan.tiers?[0].upTo, 1)
+                XCTAssertEqual(sub.items.data[1].plan.tiers?[1].amount, 200)
+                XCTAssertEqual(sub.items.data[1].plan.tiers?[1].upTo, nil)
+                XCTAssertEqual(sub.items.data[1].plan.tiersMode, .graduated)
                 
                 // These cover the Plan object
                 XCTAssertNotNil(sub.plan)
@@ -196,10 +207,54 @@ class SubscriptionTests: XCTestCase {
           },
           "nickname": "Foo",
           "product": "prod_1234",
+          "transform_usage": {
+            "divide_by": 5,
+            "round": "up"
+          },
           "trial_period_days": 3
         },
         "quantity": 1,
         "subscription": "sub_AJ6s2Iy65K3RxN"
+      },
+      {
+        "id": "si_DKeuh94LM6FNyn",
+        "object": "subscription_item",
+        "created": 1533050240,
+        "metadata": {
+        },
+        "plan": {
+          "id": "plan_DIkuyHGrZFW7DN",
+          "object": "plan",
+          "active": true,
+          "aggregate_usage": null,
+          "amount": null,
+          "billing_scheme": "tiered",
+          "created": 1532611277,
+          "currency": "usd",
+          "interval": "week",
+          "interval_count": 1,
+          "livemode": false,
+          "metadata": {
+          },
+          "nickname": "Bar",
+          "product": "prod_DIksc7vKNkuiw3",
+          "tiers": [
+            {
+              "amount": 0,
+              "up_to": 1
+            },
+            {
+              "amount": 200,
+              "up_to": null
+            }
+          ],
+          "tiers_mode": "graduated",
+          "transform_usage": null,
+          "trial_period_days": null,
+          "usage_type": "licensed"
+        },
+        "quantity": 8,
+        "subscription": "sub_DKeur6TMKSqZqB"
       }
     ],
     "has_more": false,


### PR DESCRIPTION
Subscription Plans that use pricing tiers currently fail to decode as `amount` is null and `tiers` is an array of dictionaries of strings to integers or nulls.

Subscription Plans that use usage transformation currently fail to decode as `transform_usage` is a dictionary of string to integers or strings.

This MR solve the problem by making `amount` optional and adding `Tier` and `UsageTransformation` types.

I also took the liberty to rename all the types related to the subscription plan billing scheme inside an extension of `StripePlan`. 