### PR TITLE
Make StripeSubscription.quantity optional

### DIFF
--- a/Sources/Stripe/Models/Subscriptions/Subscription.swift
+++ b/Sources/Stripe/Models/Subscriptions/Subscription.swift
@@ -32,7 +32,7 @@ public struct StripeSubscription: StripeModel {
     public var livemode: Bool
     public var metadata: [String: String]
     public var plan: StripePlan?
-    public var quantity: Int
+    public var quantity: Int?
     public var start: Date?
     public var status: StripeSubscriptionStatus
     public var taxPercent: Decimal?


### PR DESCRIPTION
A Subscription that contains multiple Items has its `quantity` set to `null`.