### PR TITLE
Percent-encode query parameters to prevent injection and bugs

### DIFF
--- a/Tests/StripeTests/QueryEncodingTests.swift
+++ b/Tests/StripeTests/QueryEncodingTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Stripe
+
+class QueryEncodingTests: XCTestCase {
+    
+    func testSimpleQueryEncodedProperly() throws {
+        let query = [
+            "email": "accounting+furnitures@hmm.test"
+        ]
+        XCTAssertEqual(query.queryParameters, "email=accounting%2Bfurnitures@hmm.test")
+    }
+    
+    func testNestedDictionaryQueryEncodedProperly() throws {
+        let query: [String: Any] = [
+            "shipping": ["name": "Hamlin, Hamlin & McGill"]
+        ]
+        XCTAssertEqual(query.queryParameters, "shipping[name]=Hamlin,%20Hamlin%20%26%20McGill")
+    }
+    
+    func testNestedArrayQueryEncodedProperly() throws {
+        let query: [String: Any] = [
+            "items": [["plan": "plan_b"], ["plan": "plan_nine"]]
+        ]
+        XCTAssertEqual(query.queryParameters, "items[0][plan]=plan_b&items[1][plan]=plan_nine")
+    }
+}

--- a/Tests/StripeTests/XCTestManifests.swift
+++ b/Tests/StripeTests/XCTestManifests.swift
@@ -74,6 +74,14 @@ extension ProductTests {
     ]
 }
 
+extension QueryEncodingTests {
+    static let __allTests = [
+        ("testNestedArrayQueryEncodedProperly", testNestedArrayQueryEncodedProperly),
+        ("testNestedDictionaryQueryEncodedProperly", testNestedDictionaryQueryEncodedProperly),
+        ("testSimpleQueryEncodedProperly", testSimpleQueryEncodedProperly),
+    ]
+}
+
 extension RefundTests {
     static let __allTests = [
         ("testRefundParsedProperly", testRefundParsedProperly),


### PR DESCRIPTION
This fixes #69.

This module uses its own implementation of `URLEncodedFormSerializer` that includes indices in array key-paths (`items[0][plan]=...` instead of `items[][plan]=...`). We should probably try to migrate to URLEncodedForm in the future.