### PR TITLE
Add public constructors for ShippingLabel and StripeAddress

### DIFF
--- a/Sources/Stripe/Models/Shipping/ShippingLabel.swift
+++ b/Sources/Stripe/Models/Shipping/ShippingLabel.swift
@@ -18,6 +18,18 @@ public struct ShippingLabel: StripeModel {
     public var phone: String?
     public var trackingNumber: String?
     
+    public init(address: StripeAddress? = nil,
+                carrier: String? = nil,
+                name: String? = nil,
+                phone: String? = nil,
+                trackingNumber: String? = nil) {
+        self.address = address
+        self.carrier = carrier
+        self.name = name
+        self.phone = phone
+        self.trackingNumber = trackingNumber
+    }
+    
     public enum CodingKeys: String, CodingKey {
         case address
         case carrier

--- a/Sources/Stripe/Models/Shipping/StripeAddress.swift
+++ b/Sources/Stripe/Models/Shipping/StripeAddress.swift
@@ -19,6 +19,20 @@ public struct StripeAddress: StripeModel {
     public var postalCode: String?
     public var state: String?
     
+    public init(city: String? = nil,
+                country: String? = nil,
+                line1: String? = nil,
+                line2: String? = nil,
+                postalCode: String? = nil,
+                state: String? = nil) {
+        self.city = city
+        self.country = country
+        self.line1 = line1
+        self.line2 = line2
+        self.postalCode = postalCode
+        self.state = state
+    }
+    
     public enum CodingKeys: String, CodingKey {
         case city
         case country


### PR DESCRIPTION
Developers need to be able to construct theses types in order to pass them to `CustomerRoutes.create`.