### PR TITLE
Make Tier and UsageTansformation properties public and add constructors

### DIFF
--- a/Sources/Stripe/Models/Plans/BillingScheme.swift
+++ b/Sources/Stripe/Models/Plans/BillingScheme.swift
@@ -40,8 +40,8 @@ extension StripePlan {
     }
     
     public struct UsageTransformation: Codable {
-        public var divideBy: Int
-        public var round: RoundMode
+        public var divideBy: Int?
+        public var round: RoundMode?
         
         init(divideBy: Int, round: RoundMode) {
             self.divideBy = divideBy

--- a/Sources/Stripe/Models/Plans/BillingScheme.swift
+++ b/Sources/Stripe/Models/Plans/BillingScheme.swift
@@ -20,8 +20,13 @@ extension StripePlan {
     }
     
     public struct Tier: Codable {
-        var amount: Int?
-        var upTo: Int?
+        public var amount: Int
+        public var upTo: Int?
+        
+        public init(amount: Int, upTo: Int? = nil) {
+            self.amount = amount
+            self.upTo = upTo
+        }
         
         public enum CodingKeys: String, CodingKey {
             case amount
@@ -35,8 +40,13 @@ extension StripePlan {
     }
     
     public struct UsageTransformation: Codable {
-        var divideBy: Int?
-        var round: RoundMode?
+        public var divideBy: Int
+        public var round: RoundMode
+        
+        init(divideBy: Int, round: RoundMode) {
+            self.divideBy = divideBy
+            self.round = round
+        }
         
         public enum CodingKeys: String, CodingKey {
             case divideBy = "divide_by"


### PR DESCRIPTION
I also changed `Tier.amount`, `UsageTransformation.divideBy` and `UsageTransformation.round` from optional to non-optional. This shouldn't break existing code.


(For a moment, that PR contained a commit that renamed `Tier.amount` to `Tier.unitAmount` before I noticed we're still using API version 2018-07-27)