### PR TITLE
Created StripeDeclineCode.testModeLiveCard case

### DIFF
--- a/Sources/Stripe/Errors/StripeError.swift
+++ b/Sources/Stripe/Errors/StripeError.swift
@@ -210,6 +210,7 @@ public enum StripeDeclineCode: String, StripeModel {
     case stolenCard = "stolen_card"
     case stopPaymentOrder = "stop_payment_order"
     case testmodeDecline = "testmode_decline"
+    case testModeLiveCard = "test_mode_live_card"
     case transactionNotAllowed = "transaction_not_allowed"
     case tryAgainLater = "try_again_later"
     case withdrawalCountLimitExceeded = "withdrawal_count_limit_exceeded"


### PR DESCRIPTION
I was working with test keys for Stripe's API and I received an error response where the `decline_code` value was `test_mode_live_card`. This case is both not documented by Stripe and does not exist in the `StripeDeclineCode` enum, so I added it.