### PR TITLE
Invoice properties

### DIFF
--- a/Sources/Stripe/Helpers/StripeStatus.swift
+++ b/Sources/Stripe/Helpers/StripeStatus.swift
@@ -26,6 +26,15 @@ public enum StripeSubscriptionStatus: String, Codable {
     case unpaid
 }
 
+// https://stripe.com/docs/api/invoices/object#invoice_object-status
+public enum StripeInvoiceStatus: String, Codable {
+    case draft
+    case open
+    case paid
+    case uncollectible
+    case void
+}
+
 public enum LegalEntityVerificationStatus: String, Codable {
     case unverified
     case pending

--- a/Sources/Stripe/Models/Invoices/BillingReason.swift
+++ b/Sources/Stripe/Models/Invoices/BillingReason.swift
@@ -1,0 +1,18 @@
+//
+//  BillingReason.swift
+//  Stripe
+//
+//  Created by Nicolas Bachschmidt on 2018-11-23.
+//
+
+import Foundation
+
+// https://stripe.com/docs/api/invoices/object?lang=curl#invoice_object-billing_reason
+public enum StripeBillingReason: String, Codable {
+    case subscriptionCreate = "subscription_create"
+    case subscriptionUpdate = "subscription_update"
+    case subscriptionCycle  = "subscription_cycle"
+    case subscription       = "subscription"
+    case manual
+    case upcoming
+}

--- a/Sources/Stripe/Models/Invoices/Invoice.swift
+++ b/Sources/Stripe/Models/Invoices/Invoice.swift
@@ -24,7 +24,7 @@ public struct StripeInvoice: StripeModel {
     public var attempted: Bool?
     public var autoAdvance: Bool?
     public var billing: String?
-    public var billingReason: String?
+    public var billingReason: StripeBillingReason?
     public var charge: String?
     public var closed: Bool?
     public var currency: StripeCurrency?

--- a/Sources/Stripe/Models/Invoices/Invoice.swift
+++ b/Sources/Stripe/Models/Invoices/Invoice.swift
@@ -17,19 +17,25 @@ public struct StripeInvoice: StripeModel {
     public var id: String?
     public var object: String
     public var amountDue: Int?
+    public var amountPaid: Int?
+    public var amountRemanining: Int?
     public var applicationFee: Int?
     public var attemptCount: Int?
     public var attempted: Bool?
+    public var autoAdvance: Bool?
     public var billing: String?
+    public var billingReason: String?
     public var charge: String?
     public var closed: Bool?
     public var currency: StripeCurrency?
     public var customer: String?
     public var date: Date?
+    public var defaultSource: String?
     public var description: String?
     public var discount: StripeDiscount?
     public var dueDate: Date?
     public var endingBalance: Int?
+    public var finalizedAt: Date?
     public var forgiven: Bool?
     public var hostedInvoiceUrl: String?
     public var invoicePdf: String?
@@ -44,6 +50,7 @@ public struct StripeInvoice: StripeModel {
     public var receiptNumber: String?
     public var startingBalance: Int?
     public var statementDescriptor: String?
+    public var status: StripeInvoiceStatus?
     public var subscription: String?
     public var subscriptionProrationDate: Int?
     public var subtotal: Int?
@@ -56,19 +63,25 @@ public struct StripeInvoice: StripeModel {
         case id
         case object
         case amountDue = "amount_due"
+        case amountPaid = "amount_paid"
+        case amountRemanining = "amount_remaining"
         case applicationFee = "application_fee"
         case attemptCount = "attempt_count"
         case attempted
+        case autoAdvance = "auto_advance"
         case billing
+        case billingReason = "billing_reason"
         case charge
         case closed
         case currency
         case customer
         case date
+        case defaultSource = "default_source"
         case description
         case discount
         case dueDate = "due_date"
         case endingBalance = "ending_balance"
+        case finalizedAt = "finalized_at"
         case forgiven
         case hostedInvoiceUrl = "hosted_invoice_url"
         case invoicePdf = "invoice_pdf"
@@ -83,6 +96,7 @@ public struct StripeInvoice: StripeModel {
         case receiptNumber = "receipt_number"
         case startingBalance = "starting_balance"
         case statementDescriptor = "statement_descriptor"
+        case status
         case subscription
         case subscriptionProrationDate = "subscription_proration_date"
         case subtotal

--- a/Tests/StripeTests/InvoiceTests.swift
+++ b/Tests/StripeTests/InvoiceTests.swift
@@ -94,7 +94,7 @@ class InvoiceTests: XCTestCase {
                 XCTAssertEqual(invoice.attempted, false)
                 XCTAssertEqual(invoice.autoAdvance, true)
                 XCTAssertEqual(invoice.billing, "charge_automatically")
-                XCTAssertEqual(invoice.billingReason, "manual")
+                XCTAssertEqual(invoice.billingReason, .manual)
                 XCTAssertEqual(invoice.closed, false)
                 XCTAssertEqual(invoice.currency, .usd)
                 XCTAssertEqual(invoice.customer, "cus_CCiTI4Tpghl0nK")

--- a/Tests/StripeTests/InvoiceTests.swift
+++ b/Tests/StripeTests/InvoiceTests.swift
@@ -14,14 +14,20 @@ class InvoiceTests: XCTestCase {
     let invoiceString = """
 {
     "amount_due": 0,
+    "amount_paid": 0,
+    "amount_remaining": 0,
     "attempt_count": 0,
     "attempted": false,
+    "auto_advance": true,
     "billing": "charge_automatically",
+    "billing_reason": "manual",
     "closed": false,
     "currency": "usd",
     "customer": "cus_CCiTI4Tpghl0nK",
     "date": 1234567890,
+    "default_source": null,
     "due_date": 1234567890,
+    "finalized_at": 1234567890,
     "forgiven": false,
     "hosted_invoice_url": "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT",
     "invoice_pdf": "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT/pdf",
@@ -61,6 +67,7 @@ class InvoiceTests: XCTestCase {
     "period_end": 1234567890,
     "period_start": 1234567890,
     "starting_balance": 0,
+    "status": "open",
     "subtotal": 0,
     "total": 0,
     "webhooks_delivered_at": 1234567890
@@ -81,14 +88,20 @@ class InvoiceTests: XCTestCase {
             futureInvoice.do { (invoice) in
                 XCTAssertEqual(invoice.id, "in_1BoJ2NKrZ43eBVAbQ8jb0Xfj")
                 XCTAssertEqual(invoice.amountDue, 0)
+                XCTAssertEqual(invoice.amountPaid, 0)
+                XCTAssertEqual(invoice.amountRemanining, 0)
                 XCTAssertEqual(invoice.attemptCount, 0)
                 XCTAssertEqual(invoice.attempted, false)
+                XCTAssertEqual(invoice.autoAdvance, true)
                 XCTAssertEqual(invoice.billing, "charge_automatically")
+                XCTAssertEqual(invoice.billingReason, "manual")
                 XCTAssertEqual(invoice.closed, false)
                 XCTAssertEqual(invoice.currency, .usd)
                 XCTAssertEqual(invoice.customer, "cus_CCiTI4Tpghl0nK")
                 XCTAssertEqual(invoice.date, Date(timeIntervalSince1970: 1234567890))
+                XCTAssertEqual(invoice.defaultSource, nil)
                 XCTAssertEqual(invoice.dueDate, Date(timeIntervalSince1970: 1234567890))
+                XCTAssertEqual(invoice.finalizedAt, Date(timeIntervalSince1970: 1234567890))
                 XCTAssertEqual(invoice.forgiven, false)
                 XCTAssertEqual(invoice.hostedInvoiceUrl, "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT")
                 XCTAssertEqual(invoice.invoicePdf, "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT/pdf")
@@ -100,6 +113,7 @@ class InvoiceTests: XCTestCase {
                 XCTAssertEqual(invoice.periodEnd, Date(timeIntervalSince1970: 1234567890))
                 XCTAssertEqual(invoice.periodStart, Date(timeIntervalSince1970: 1234567890))
                 XCTAssertEqual(invoice.startingBalance, 0)
+                XCTAssertEqual(invoice.status, .open)
                 XCTAssertEqual(invoice.subtotal, 0)
                 XCTAssertEqual(invoice.total, 0)
                 XCTAssertEqual(invoice.webhooksDeliveredAt, Date(timeIntervalSince1970: 1234567890))


### PR DESCRIPTION
This MR adds a few properties to `StripeInvoice`.

It also adds two types:

* `StripeInvoiceStatus`: This type is an enum of the statuses described in [the documentation](https://stripe.com/docs/api/invoices/object#invoice_object-status).
* `StripeBillingReason`: This type is not an enum but a raw-representable struct because we must be ready to accept unexpected values. In particular [the documentation](https://stripe.com/docs/api/invoices/object?lang=curl#invoice_object-billing_reason) does not mention `subscription_created`, which will become available when switching to [API version 2018-10-31](https://stripe.com/docs/upgrades#2018-10-31). Currently, there are no declarations for `subscription_created` (which is represented as `subscription_updated` for now) nor `subscription` (which appears only in old invoices) in order to avoid confusion.