### PR TITLE
Fix balance history endpoint

### DIFF
--- a/Sources/Stripe/API/Routes/BalanceRoutes.swift
+++ b/Sources/Stripe/API/Routes/BalanceRoutes.swift
@@ -54,6 +54,6 @@ public struct StripeBalanceRoutes: BalanceRoutes {
         if let filter = filter {
             queryParams = filter.queryParameters
         }
-        return try request.send(method: .GET, path: StripeAPIEndpoint.balance.endpoint, query: queryParams)
+        return try request.send(method: .GET, path: StripeAPIEndpoint.balanceHistory.endpoint, query: queryParams)
     }
 }

--- a/Sources/Stripe/Helpers/StripeStatus.swift
+++ b/Sources/Stripe/Helpers/StripeStatus.swift
@@ -15,6 +15,7 @@ public enum StripeStatus: String, Codable {
     case pending
     case canceled
     case chargeable
+    case available
 }
 
 // https://stripe.com/docs/api/curl#subscription_object-status

--- a/Sources/Stripe/Models/Balance/BalanceHistoryList.swift
+++ b/Sources/Stripe/Models/Balance/BalanceHistoryList.swift
@@ -16,7 +16,7 @@ public struct BalanceHistoryList: StripeModel {
     public var hasMore: Bool?
     public var totalCount: Int?
     public var url: String?
-    public var data: [StripeBalance]?
+    public var data: [StripeBalanceTransactionItem]?
     
     public enum CodingKeys: String, CodingKey {
         case object


### PR DESCRIPTION
The current model implemented on BalanceHistoryList.data mismatch the current response from the stripe. The correct model for data is: StripeBalanceTransactionItem. The endpoint mismatch the correct one implemented by Stripe too. See more at: https://stripe.com/docs/api/balance/balance_history?lang=curl

▿ BalanceHistoryList
  - object : "list"
  ▿ hasMore : Optional<Bool>
    - some : true
  - totalCount : nil
  ▿ url : Optional<String>
    - some : "/v1/balance/history"
  ▿ data : Optional<Array<StripeBalanceTransactionItem>>
    ▿ some : 10 elements
      ▿ 0 : StripeBalanceTransactionItem
        - id : "XXXXXXXXXXXXXXXXXXXXXXX"
        - object : "balance_transaction"
        ▿ amount : Optional<Int>
          - some : 1844825
        ▿ availableOn : Optional<Date>
          ▿ some : 2019-01-29 00:00:00 +0000
            - timeIntervalSinceReferenceDate : 570412800.0
        ▿ created : Optional<Date>
          ▿ some : 2019-01-22 09:27:23 +0000
            - timeIntervalSinceReferenceDate : 569842043.0
        ▿ currency : Optional<StripeCurrency>
          - some : Stripe.StripeCurrency.nok
        ▿ exchangeRate : Optional<NSDecimal>
          ▿ some : 8.38557
            ▿ _mantissa : 8 elements
              - .0 : 52125
              - .1 : 12
              - .2 : 0
              - .3 : 0
              - .4 : 0
              - .5 : 0
              - .6 : 0
              - .7 : 0
        ▿ description : Optional<String>
          - some : "Payment for invoice XXXXX-XXXX"
        ▿ fee : Optional<Int>
          - some : 53700
        ▿ feeDetails : Optional<Array<StripeFee>>
          ▿ some : 1 element
            ▿ 0 : StripeFee
              ▿ amount : Optional<Int>
                - some : 53700
              ▿ currency : Optional<StripeCurrency>
                - some : Stripe.StripeCurrency.nok
              ▿ description : Optional<String>
                - some : "Stripe processing fees"
              ▿ type : Optional<ActionType>
                - some : Stripe.ActionType.stripeFee
        ▿ net : Optional<Int>
          - some : 1791125
        ▿ source : Optional<String>
          - some : "XXXXXXXXXXXXXX"
        ▿ status : Optional<StripeStatus>
          - some : Stripe.StripeStatus.pending
        ▿ type : Optional<BalanceTransactionType>
          - some : Stripe.BalanceTransactionType.charge