### PR TITLE
Adds basic PaymentIntents support

### DIFF
--- a/Sources/Stripe/API/Helpers/Endpoints.swift
+++ b/Sources/Stripe/API/Helpers/Endpoints.swift
@@ -123,6 +123,13 @@ internal enum StripeAPIEndpoint {
     case file
     case files(String)
     
+    // MARK: - PAYMENT INTENTS
+    case paymentIntent
+    case paymentIntents(String)
+    case paymentIntentsCapture(String)
+    case paymentIntentsConfirm(String)
+    case paymentIntentsCancel(String)
+
     var endpoint: String {
         switch self {
         case .balance: return APIBase + APIVersion + "balance"
@@ -210,6 +217,13 @@ internal enum StripeAPIEndpoint {
         
         case .file: return FilesAPIBase + APIVersion + "files"
         case .files(let id): return FilesAPIBase + APIVersion + "files/\(id)"
+
+        case .paymentIntent: return APIBase + APIVersion + "payment_intents"
+        case .paymentIntents(let id): return APIBase + APIVersion + "payment_intents\(id)"
+        case .paymentIntentsCancel(let id): return APIBase + APIVersion + "payment_intents\(id)/cancel"
+        case .paymentIntentsConfirm(let id): return APIBase + APIVersion + "payment_intents\(id)/confirm"
+        case .paymentIntentsCapture(let id): return APIBase + APIVersion + "payment_intents\(id)/capture"
+
         }
     }
 }

--- a/Sources/Stripe/API/Routes/OrderRoutes.swift
+++ b/Sources/Stripe/API/Routes/OrderRoutes.swift
@@ -93,7 +93,7 @@ public struct StripeOrderRoutes: OrderRoutes {
                        items: [[String: Any]]?,
                        metadata: [String: String]?,
                        shipping: ShippingLabel?) throws -> Future<StripeOrder> {
-        var body: [String: Any] = [:]
+        var body: [String: Any] = ["currency": currency.rawValue]
         
         if let coupon = coupon {
             body["coupon"] = coupon

--- a/Sources/Stripe/API/Routes/PaymentIntentsRoutes.swift
+++ b/Sources/Stripe/API/Routes/PaymentIntentsRoutes.swift
@@ -1,0 +1,398 @@
+//
+//  PaymentIntentsRoutes.swift
+//  Stripe
+//
+//  Created by Ben Syverson on 2019-02-28
+//
+//
+
+import Vapor
+
+public protocol PaymentIntentsRoutes {
+    func create(amount: Int, currency: StripeCurrency, paymentMethodTypes: [SourceType], applicationFeeAmount: Int?, captureMethod: CaptureMethod?, confirm: Bool?, customer: String?, description: String?, metadata: [String : String]?, onBehalfOf: String?, receiptEmail: String?, returnUrl: String?, savePaymentMethod: Bool?, shipping: [String: Any]?, source: String?, statementDescriptor: String?, transferData: [String: Any]?, transferGroup: String?) throws -> Future<StripePaymentIntents>
+    func retrieve(paymentIntents: String) throws -> Future<StripePaymentIntents>
+    func update(paymentIntents: String, amount: Int?, applicationFeeAmount: Int?, currency: StripeCurrency?, customer: String?, description: String?, metadata: [String : String]?, paymentMethodTypes: [SourceType]?, receiptEmail: String?, returnUrl: String?, savePaymentMethod: Bool?, shipping: [String: Any]?, source: String?, transferData: [String: Any]?, transferGroup: String?) throws -> Future<StripePaymentIntents>
+    func confirm(paymentIntents: String, clientSecret: String?, receiptEmail: String?, returnUrl: String?, savePaymentMethod: Bool?, shipping: [String: Any]?, source: String?) throws -> Future<StripePaymentIntents>
+    func capture(paymentIntents: String, amountToCapture: Int?, applicationFeeAmount: Int?) throws -> Future<StripePaymentIntents>
+    func cancel(paymentIntents: String, cancellationReason: CancellationReason?) throws -> Future<StripePaymentIntents>
+    func listAll(filter: [String: Any]?) throws -> Future<StripePaymentIntents>
+}
+
+extension PaymentIntentsRoutes {
+    public func create(amount: Int,
+                       currency: StripeCurrency,
+                       paymentMethodTypes: [SourceType] = [.card],
+                       applicationFeeAmount: Int? = nil,
+                       captureMethod: CaptureMethod? = nil,
+                       confirm: Bool? = nil,
+                       customer: String? = nil,
+                       description: String? = nil,
+                       metadata: [String : String]? = nil,
+                       onBehalfOf: String? = nil,
+                       receiptEmail: String? = nil,
+                       returnUrl: String? = nil,
+                       savePaymentMethod: Bool? = nil,
+                       shipping: [String: Any]? = nil,
+                       source: String? = nil,
+                       statementDescriptor: String? = nil,
+                       transferData: [String: Any]? = nil,
+                       transferGroup: String? = nil) throws -> Future<StripePaymentIntents> {
+        return try create(amount: amount,
+                          currency: currency,
+                          paymentMethodTypes: paymentMethodTypes,
+                          applicationFeeAmount: applicationFeeAmount,
+                          captureMethod: captureMethod,
+                          confirm: confirm,
+                          customer: customer,
+                          description: description,
+                          metadata: metadata,
+                          onBehalfOf: onBehalfOf,
+                          receiptEmail: receiptEmail,
+                          returnUrl: returnUrl,
+                          savePaymentMethod: savePaymentMethod,
+                          shipping: shipping,
+                          source: source,
+                          statementDescriptor: statementDescriptor,
+                          transferData: transferData,
+                          transferGroup: transferGroup)
+    }
+    
+    public func confirm(paymentIntents: String,
+                       clientSecret: String? = nil,
+                       receiptEmail: String? = nil,
+                       returnUrl: String? = nil,
+                       savePaymentMethod: Bool? = nil,
+                       shipping: [String: Any]? = nil,
+                       source: String? = nil) throws -> Future<StripePaymentIntents> {
+        return try confirm(paymentIntents: paymentIntents,
+                          clientSecret: clientSecret,
+                          receiptEmail: receiptEmail,
+                          returnUrl: returnUrl,
+                          savePaymentMethod: savePaymentMethod,
+                          shipping: shipping,
+                          source: source)
+    }
+    
+    public func capture(paymentIntents: String,
+                        amountToCapture: Int? = nil,
+                        applicationFeeAmount: Int? = nil) throws -> Future<StripePaymentIntents> {
+        return try capture(paymentIntents: paymentIntents,
+                           amountToCapture: amountToCapture,
+                           applicationFeeAmount: applicationFeeAmount)
+    }
+    
+    public func cancel(paymentIntents: String,
+                        cancellationReason: CancellationReason? = nil) throws -> Future<StripePaymentIntents> {
+        return try cancel(paymentIntents: paymentIntents,
+                           cancellationReason: cancellationReason)
+    }
+    
+    public func update(paymentIntents: String,
+                       amount: Int? = nil,
+                       applicationFeeAmount: Int? = nil,
+                       currency: StripeCurrency? = nil,
+                       customer: String? = nil,
+                       description: String? = nil,
+                       metadata: [String : String]? = nil,
+                       paymentMethodTypes: [SourceType]? = nil,
+                       receiptEmail: String? = nil,
+                       returnUrl: String? = nil,
+                       savePaymentMethod: Bool? = nil,
+                       shipping: [String: Any]? = nil,
+                       source: String? = nil,
+                       transferData: [String: Any]? = nil,
+                       transferGroup: String? = nil) throws -> Future<StripePaymentIntents> {
+        return try update(paymentIntents: paymentIntents,
+                          amount: amount,
+                          applicationFeeAmount: applicationFeeAmount,
+                          currency: currency,
+                          customer: customer,
+                          description: description,
+                          metadata: metadata,
+                          paymentMethodTypes: paymentMethodTypes,
+                          receiptEmail: receiptEmail,
+                          returnUrl: returnUrl,
+                          savePaymentMethod: savePaymentMethod,
+                          shipping: shipping,
+                          source: source,
+                          transferData: transferData,
+                          transferGroup: transferGroup)
+    }
+
+    public func retrieve(id: String) throws -> Future<StripePaymentIntents> {
+        return try retrieve(id: id)
+    }
+    
+    public func listAll(filter: [String : Any]? = nil) throws -> Future<StripePaymentIntents> {
+        return try listAll(filter: filter)
+    }
+}
+
+public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
+    private let request: StripeRequest
+
+    init(request: StripeRequest) {
+        self.request = request
+    }
+
+
+    /// Create a PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/curl#create_charge)
+    public func create(amount: Int,
+                       currency: StripeCurrency,
+                       paymentMethodTypes: [SourceType],
+                       applicationFeeAmount: Int?,
+                       captureMethod: CaptureMethod?,
+                       confirm: Bool?,
+                       customer: String?,
+                       description: String?,
+                       metadata: [String : String]?,
+                       onBehalfOf: String?,
+                       receiptEmail: String?,
+                       returnUrl: String?,
+                       savePaymentMethod: Bool?,
+                       shipping: [String: Any]?,
+                       source: String?,
+                       statementDescriptor: String?,
+                       transferData: [String: Any]?,
+                       transferGroup: String?) throws -> Future<StripePaymentIntents> {
+        var body: [String: Any] = ["amount": amount, "currency": currency.rawValue]
+        
+        for (index, method) in paymentMethodTypes.enumerated() {
+            body["payment_method_types[\(index)]"] = method.rawValue
+        }
+        
+        if let applicationFeeAmount = applicationFeeAmount {
+            body["application_fee_amount"] = applicationFeeAmount
+        }
+        
+        if let captureMethod = captureMethod {
+            body["capture_method"] = captureMethod.rawValue
+        }
+        
+        if let confirm = confirm {
+            body["confirm"] = confirm
+        }
+        
+        if let customer = customer {
+            body["customer"] = customer
+        }
+        
+        if let description = description {
+            body["description"] = description
+        }
+        
+        if let metadata = metadata {
+            metadata.forEach { body["metadata[\($0)]"] = $1}
+        }
+        
+        if let onBehalfOf = onBehalfOf {
+            body["on_behalf_of"] = onBehalfOf
+        }
+        
+        if let receiptEmail = receiptEmail {
+            body["receipt_email"] = receiptEmail
+        }
+        
+        if let returnUrl = returnUrl {
+            body["return_url"] = returnUrl
+        }
+        
+        if let savePaymentMethod = savePaymentMethod {
+            body["save_payment_method"] = savePaymentMethod
+        }
+        
+        if let shipping = shipping {
+            shipping.forEach { body["shipping[\($0)]"] = $1 }
+        }
+        
+        if let source = source {
+            body["source"] = source
+        }
+        
+        if let statementDescriptor = statementDescriptor {
+            body["statement_descriptor"] = statementDescriptor
+        }
+        
+        if let transferData = transferData {
+            transferData.forEach { body["transfer_data[\($0)]"] = $1 }
+        }
+        
+        if let transferGroup = transferGroup {
+            body["transfer_group"] = transferGroup
+        }
+        
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntent.endpoint, body: body.queryParameters)
+    }
+    
+    /// Retrieve a PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/payment_intents/retrieve?lang=curl)
+    public func retrieve(paymentIntents: String) throws -> Future<StripePaymentIntents> {
+        return try request.send(method: .GET, path: StripeAPIEndpoint.paymentIntents(paymentIntents).endpoint)
+    }
+
+    /// Update a PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/payment_intents/update?lang=curl)
+    public func update(paymentIntents: String,
+                       amount: Int?,
+                       applicationFeeAmount: Int?,
+                       currency: StripeCurrency?,
+                       customer: String?,
+                       description: String?,
+                       metadata: [String : String]?,
+                       paymentMethodTypes: [SourceType]?,
+                       receiptEmail: String?,
+                       returnUrl: String?,
+                       savePaymentMethod: Bool?,
+                       shipping: [String: Any]?,
+                       source: String?,
+                       transferData: [String: Any]?,
+                       transferGroup: String?) throws -> Future<StripePaymentIntents> {
+        
+        var body: [String: Any] = [:]
+        
+        if let amount = amount {
+            body["amount"] = amount
+        }
+        
+        if let applicationFeeAmount = applicationFeeAmount {
+            body["application_fee_amount"] = applicationFeeAmount
+        }
+
+        if let currency = currency {
+            body["currency"] = currency
+        }
+        
+        if let customer = customer {
+            body["customer"] = customer
+        }
+        
+        if let description = description {
+            body["description"] = description
+        }
+        
+        if let metadata = metadata {
+            metadata.forEach { body["metadata[\($0)]"] = $1}
+        }
+        
+        if let paymentMethodTypes = paymentMethodTypes {
+            for (index, method) in paymentMethodTypes.enumerated() {
+                body["payment_method_types[\(index)]"] = method.rawValue
+            }
+        }
+        
+        if let receiptEmail = receiptEmail {
+            body["receipt_email"] = receiptEmail
+        }
+        
+        if let returnUrl = returnUrl {
+            body["return_url"] = returnUrl
+        }
+        
+        if let savePaymentMethod = savePaymentMethod {
+            body["save_payment_method"] = savePaymentMethod
+        }
+        
+        if let shipping = shipping {
+            shipping.forEach { body["shipping[\($0)]"] = $1 }
+        }
+        
+        if let source = source {
+            body["source"] = source
+        }
+        
+        if let transferData = transferData {
+            transferData.forEach { body["transfer_data[\($0)]"] = $1 }
+        }
+        
+        if let transferGroup = transferGroup {
+            body["transfer_group"] = transferGroup
+        }
+
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntents(paymentIntents).endpoint, body: body.queryParameters)
+    }
+
+    /// Confirm a PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/payment_intents/confirm?lang=curl)
+    public func confirm(paymentIntents: String,
+                        clientSecret: String? = nil,
+                        receiptEmail: String? = nil,
+                        returnUrl: String? = nil,
+                        savePaymentMethod: Bool? = nil,
+                        shipping: [String: Any]? = nil,
+                        source: String? = nil) throws -> Future<StripePaymentIntents> {
+        
+        var body: [String: Any] = [:]
+        
+        if let clientSecret = clientSecret {
+            body["client_secret"] = clientSecret
+        }
+        
+        if let receiptEmail = receiptEmail {
+            body["receipt_email"] = receiptEmail
+        }
+        
+        if let returnUrl = returnUrl {
+            body["return_url"] = returnUrl
+        }
+        
+        if let savePaymentMethod = savePaymentMethod {
+            body["save_payment_method"] = savePaymentMethod
+        }
+        
+        if let shipping = shipping {
+            shipping.forEach { body["shipping[\($0)]"] = $1 }
+        }
+        
+        if let source = source {
+            body["source"] = source
+        }
+        
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntentsConfirm(paymentIntents).endpoint, body: body.queryParameters)
+    }
+
+    /// Capture a PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/payment_intents/capture?lang=curl)
+    public func capture(paymentIntents: String,
+                        amountToCapture: Int? = nil,
+                        applicationFeeAmount: Int? = nil) throws -> Future<StripePaymentIntents> {
+        
+        var body: [String: Any] = [:]
+        
+        if let amountToCapture = amountToCapture {
+            body["amount_to_capture"] = amountToCapture
+        }
+        
+        if let applicationFeeAmount = applicationFeeAmount {
+            body["application_fee_amount"] = applicationFeeAmount
+        }
+        
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntentsCapture(paymentIntents).endpoint, body: body.queryParameters)
+    }
+    
+    
+    /// Cancel a PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/payment_intents/cancel?lang=curl)
+    public func cancel(paymentIntents: String,
+                       cancellationReason: CancellationReason? = nil) throws -> Future<StripePaymentIntents> {
+        
+        var body: [String: Any] = [:]
+        
+        if let cancellationReason = cancellationReason {
+            body["cancellation_reason"] = cancellationReason.rawValue
+        }
+        
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntentsCancel(paymentIntents).endpoint, body: body.queryParameters)
+    }
+    
+    /// List all PaymentIntents
+    /// [Learn More →](https://stripe.com/docs/api/payment_intents/list?lang=curl)
+    public func listAll(filter: [String : Any]?) throws -> Future<StripePaymentIntents> {
+        var queryParams = ""
+        if let filter = filter {
+            queryParams = filter.queryParameters
+        }
+
+        return try request.send(method: .GET, path: StripeAPIEndpoint.paymentIntent.endpoint, query: queryParams)
+    }
+}

--- a/Sources/Stripe/Models/PaymentIntents/PaymentIntents.swift
+++ b/Sources/Stripe/Models/PaymentIntents/PaymentIntents.swift
@@ -1,0 +1,80 @@
+//
+//  PaymentIntents.swift
+//  Stripe
+//
+//  Created by Ben Syverson on 2019-02-28.
+//
+//
+
+import Foundation
+
+/**
+ Customer Model
+ https://stripe.com/docs/api/curl#payment_intents
+ */
+
+public struct StripePaymentIntents: StripeModel {
+    public var id: String
+    public var object: String
+    public var amount: Int?
+    public var amountCapturable: Int?
+    public var amountReceived: Int?
+    public var application: String?
+    public var applicationFeeAmount: Int?
+    public var canceledAt: Date?
+    public var cancellationReason: CancellationReason?
+    public var charges: ChargesList?
+    public var clientSecret: String?
+    public var confirmationMethod: ConfirmationMethod?
+    public var created: Date?
+    public var currency: StripeCurrency
+    public var customer: String?
+    public var description: String?
+    public var lastPaymentError: StripeAPIError?
+    public var livemode: Bool
+    public var metadata: [String: String]
+    public var nextAction: PaymentIntentsAction?
+    public var onBehalfOf: String?
+    public var paymentMethodTypes: [SourceType]?
+    public var receiptEmail: String?
+    public var review: String?
+    public var shipping: ShippingLabel?
+    public var source: String?
+    public var statementDescriptor: String?
+    public var status: PaymentIntentsStatus
+    public var transferData: StripeChargeTransferData?
+    public var transferGroup: String?
+    
+    public enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case amount
+        case amountCapturable = "amount_capturable"
+        case amountReceived = "amount_received"
+        case application
+        case applicationFeeAmount = "application_fee_amount"
+        case canceledAt = "canceled_at"
+        case cancellationReason = "cancellation_reason"
+        case charges
+        case clientSecret = "client_secret"
+        case confirmationMethod = "confirmation_method"
+        case created
+        case currency
+        case customer
+        case description
+        case lastPaymentError = "last_payment_error"
+        case livemode
+        case metadata
+        case nextAction = "next_action"
+        case onBehalfOf = "on_behalf_of"
+        case paymentMethodTypes = "payment_method_types"
+        case receiptEmail = "receipt_email"
+        case review
+        case shipping
+        case source
+        case statementDescriptor = "statement_descriptor"
+        case status
+        case transferData = "transfer_data"
+        case transferGroup = "transfer_group"
+    }
+}

--- a/Sources/Stripe/Models/PaymentIntents/PaymentIntentsAction.swift
+++ b/Sources/Stripe/Models/PaymentIntents/PaymentIntentsAction.swift
@@ -1,0 +1,25 @@
+//
+//  PaymentIntentsAction.swift
+//  App
+//
+//  Created by Ben Syverson on 2019/2/28.
+//
+
+import Foundation
+
+/**
+ next_action
+ https://stripe.com/docs/api/payment_intents/object?lang=curl
+*/
+
+public struct PaymentIntentsAction: StripeModel {
+    public var redirectToUrl: SourceRedirect?
+    public var type: PaymentIntentsActionType?
+    public var useStripeSDK: [String: String]?
+
+    public enum CodingKeys: String, CodingKey {
+        case redirectToUrl = "redirect_to_url"
+        case type
+        case useStripeSDK = "use_stripe_sdk"
+    }
+}

--- a/Sources/Stripe/Models/PaymentIntents/PaymentIntentsList.swift
+++ b/Sources/Stripe/Models/PaymentIntents/PaymentIntentsList.swift
@@ -1,0 +1,27 @@
+//
+//  PaymentIntentsList.swift
+//  Stripe
+//
+//  Created by Ben Syverson on 2019-02-28.
+//
+//
+/**
+ Customers List
+ https://stripe.com/docs/api/payment_intents/list?lang=curl
+ */
+
+public struct StripePaymentIntentsList: StripeModel {
+    public var object: String
+    public var hasMore: Bool
+    public var totalCount: Int?
+    public var url: String?
+    public var data: [StripePaymentIntents]?
+    
+    public enum CodingKeys: String, CodingKey {
+        case object
+        case hasMore = "has_more"
+        case totalCount = "total_count"
+        case url
+        case data
+    }
+}

--- a/Sources/Stripe/Models/PaymentIntents/PaymentIntentsSupport.swift
+++ b/Sources/Stripe/Models/PaymentIntents/PaymentIntentsSupport.swift
@@ -1,0 +1,42 @@
+//
+//  PaymentIntentsSupport.swft
+//  App
+//
+//  Created by Ben Syverson on 2019/2/28.
+//
+
+import Foundation
+
+public enum CancellationReason: String, Codable {
+    case duplicate
+    case fraudulent
+    case highest
+    case requestedByCustomer = "requested_by_customer"
+    case failedInvoice = "failed_invoice"
+}
+
+public enum CaptureMethod: String, Codable {
+    case automatic
+    case manual
+}
+
+public enum ConfirmationMethod: String, Codable {
+    case secret
+    case publishable
+}
+
+public enum PaymentIntentsStatus: String, Codable {
+    case requiresPaymentMethod = "requires_payment_method"
+    case requiresConfirmation = "requires_confirmation"
+    case requiresAction = "requires_action"
+    case processing
+    case requiresAuthorization = "requires_authorization"
+    case requiresCapture = "requires_capture"
+    case canceled
+    case succeeded
+}
+
+public enum PaymentIntentsActionType: String, Codable {
+    case redirectToUrl = "redirect_to_url"
+    case useStripeSDK = "use_stripe_sdk"
+}

--- a/Sources/Stripe/Provider/Provider.swift
+++ b/Sources/Stripe/Provider/Provider.swift
@@ -55,6 +55,7 @@ public final class StripeClient: Service {
     public var invoice: InvoiceRoutes
     public var orderReturn: OrderReturnRoutes
     public var order: OrderRoutes
+    public var paymentIntents: PaymentIntentsRoutes
     public var plan: PlanRoutes
     public var product: ProductRoutes
     public var refund: RefundRoutes
@@ -83,6 +84,7 @@ public final class StripeClient: Service {
         invoice = StripeInvoiceRoutes(request: apiRequest)
         orderReturn = StripeOrderReturnRoutes(request: apiRequest)
         order = StripeOrderRoutes(request: apiRequest)
+        paymentIntents = StripePaymentIntentsRoutes(request: apiRequest)
         plan = StripePlanRoutes(request: apiRequest)
         product = StripeProductRoutes(request: apiRequest)
         refund = StripeRefundRoutes(request: apiRequest)


### PR DESCRIPTION
This PR adds basic support for [`PaymentIntents`](https://stripe.com/docs/api/payment_intents), including:

- A new `PaymentIntents` model and supporting enums/structs
- Routes to create, retrieve, update, confirm, capture, cancel and list `PaymentIntents`
- Also fixes a minor bug in the `create` route for `StripeOrder`

I tried to stick to the style established in other files. Thanks for this amazing library! It saved me a lot of time. 👏