### PR TITLE
Fixes some compilation warnings around extraneous 'public' incantations

### DIFF
--- a/Sources/Stripe/API/StripeRequest.swift
+++ b/Sources/Stripe/API/StripeRequest.swift
@@ -16,11 +16,11 @@ public protocol StripeRequest: class {
 }
 
 public extension StripeRequest {
-    public func send<SM: StripeModel>(method: HTTPMethod, path: String, query: String = "", body: LosslessHTTPBodyRepresentable = HTTPBody(string: ""), headers: HTTPHeaders = [:]) throws -> Future<SM> {
+    func send<SM: StripeModel>(method: HTTPMethod, path: String, query: String = "", body: LosslessHTTPBodyRepresentable = HTTPBody(string: ""), headers: HTTPHeaders = [:]) throws -> Future<SM> {
         return try send(method: method, path: path, query: query, body: body, headers: headers)
     }
     
-    public func serializedResponse<SM: StripeModel>(response: HTTPResponse, worker: EventLoop) throws -> Future<SM> {
+    func serializedResponse<SM: StripeModel>(response: HTTPResponse, worker: EventLoop) throws -> Future<SM> {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         


### PR DESCRIPTION
There were a few compiler warnings when building with `vapor build --verbose` around extraneous uses of `public` annotations.

Signed-off-by: zach wick <zach@zachwick.com>