### PR TITLE
Fix PaymentIntentsRoute infinite loop when creating new request

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ And you can always check the documentation to see the required paramaters for sp
 * [ ] Events
 * [x] File Links
 * [x] File Uploads
-* [ ] PaymentIntents
+* [x] PaymentIntents
 * [x] Payouts
 * [x] Products
 * [x] Refunds

--- a/Sources/Stripe/API/Helpers/Endpoints.swift
+++ b/Sources/Stripe/API/Helpers/Endpoints.swift
@@ -126,6 +126,13 @@ internal enum StripeAPIEndpoint {
     // MARK: - PERSONS
     case person(String)
     case persons(String, String)
+
+    // MARK: - PAYMENT INTENTS
+    case paymentIntents
+    case paymentIntent(String)
+    case paymentIntentConfirm(String)
+    case paymentIntentCapture(String)
+    case paymentIntentCancel(String)
     
     var endpoint: String {
         switch self {
@@ -217,6 +224,12 @@ internal enum StripeAPIEndpoint {
         
         case .person(let account): return APIBase + APIVersion + "accounts/\(account)/persons"
         case .persons(let account, let person): return APIBase + APIVersion + "accounts/\(account)/persons\(person)"
+
+        case .paymentIntents: return APIBase + APIVersion + "payment_intents"
+        case .paymentIntent(let id): return APIBase + APIVersion + "payment_intents/\(id)"
+        case .paymentIntentConfirm(let id): return APIBase + APIVersion + "payment_intents/\(id)/confirm"
+        case .paymentIntentCapture(let id): return APIBase + APIVersion + "payment_intents/\(id)/capture"
+        case .paymentIntentCancel(let id): return APIBase + APIVersion + "payment_intents/\(id)/cancel"
         }
     }
 }

--- a/Sources/Stripe/API/Routes/InvoiceRoutes.swift
+++ b/Sources/Stripe/API/Routes/InvoiceRoutes.swift
@@ -113,7 +113,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
         body["customer"] = customer
         
         if let applicationFee = applicationFee {
-            body["application_fee"] = applicationFee
+            body["application_fee_amount"] = applicationFee
         }
         
         if let connectAccount = connectAccount {
@@ -195,7 +195,7 @@ public struct StripeInvoiceRoutes: InvoiceRoutes {
         var headers: HTTPHeaders = [:]
         
         if let applicationFee = applicationFee {
-            body["application_fee"] = applicationFee
+            body["application_fee_amount"] = applicationFee
         }
         
         if let connectAccount = connectAccount {

--- a/Sources/Stripe/API/Routes/PaymentIntentRoutes.swift
+++ b/Sources/Stripe/API/Routes/PaymentIntentRoutes.swift
@@ -1,0 +1,494 @@
+//
+//  PaymentIntentRoutes.swift
+//  Stripe
+//
+//  Created by Kristian Andersen on 08/10/2019.
+//
+
+import Vapor
+
+public protocol PaymentIntentsRoutes {
+    /// Creates a PaymentIntent object.
+    ///
+    /// - Parameters:
+    ///   - amount: A positive integer representing how much to charge in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or equivalent in charge currency.
+    ///   - currency: Three-letter ISO currency code, in lowercase. Must be a supported currency.
+    ///   - applicationFeeAmount: The amount of the application fee (if any) that will be applied to the payment and transferred to the application owner’s Stripe account. For more information, see the PaymentIntents Connect usage guide.
+    ///   - captureMethod: Capture method of this PaymentIntent, one of `automatic` or `manual`.
+    ///   - confirm: Set to `true` to attempt to confirm this PaymentIntent immediately. This parameter defaults to `false`. If the payment method attached is a card, a return_url may be provided in case additional authentication is required.
+    ///   - confirmationMethod: One of `automatic` (default) or `manual`. /n When the confirmation method is `automatic`, a PaymentIntent can be confirmed using a publishable key. After `next_actions` are handled, no additional confirmation is required to complete the payment. /n When the confirmation method is` manual`, all payment attempts must be made using a secret key. The PaymentIntent will return to the `requires_confirmation` state after handling `next_actions`, and requires your server to initiate each payment attempt with an explicit confirmation. Read the expanded documentation to learn more about manual confirmation.
+    ///   - customer: ID of the customer this PaymentIntent is for if one exists.
+    ///   - description: An arbitrary string attached to the object. Often useful for displaying to users. This will be unset if you POST an empty value.
+    ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+    ///   - onBehalfOf: The Stripe account ID for which these funds are intended. For details, see the PaymentIntents Connect usage guide.
+    ///   - paymentMethod: ID of the payment method to attach to this PaymentIntent.
+    ///   - paymentMethodTypes: The list of payment method types that this PaymentIntent is allowed to use. If this is not provided, defaults to `[“card”]`. Valid payment method types include: `card` and `card_present`.
+    ///   - receiptEmail: Email address that the receipt for the resulting payment will be sent to.
+    ///   - savePaymentMethod: Set to `true` to save the PaymentIntent’s payment method (either `source` or `payment_method`) to the associated customer. If the payment method is already attached, this parameter does nothing. This parameter defaults to `false` and applies to the payment method passed in the same request or the current payment method attached to the PaymentIntent and must be specified again if a new payment method is added.
+    ///   - shipping: Shipping information for this PaymentIntent.
+    ///   - source: ID of the Source object to attach to this PaymentIntent.
+    ///   - statementDescriptor: Extra information about a PaymentIntent. This will appear on your customer’s statement when this PaymentIntent succeeds in creating a charge.
+    ///   - transferData: The parameters used to automatically create a Transfer when the payment succeeds. For more information, see the PaymentIntents Connect usage guide.
+    ///   - transferGroup: A string that identifies the resulting payment as part of a group. See the PaymentIntents Connect usage guide for details.
+    /// - Returns: A `StripePaymentIntent`.
+    func create(amount: Int,
+                currency: StripeCurrency,
+                applicationFeeAmount: Int?,
+                captureMethod: PaymentIntentCaptureMethod?,
+                confirm: Bool?,
+                confirmationMethod: PaymentIntentConfirmationMethod?,
+                customer: String?,
+                description: String?,
+                metadata: [String: String]?,
+                onBehalfOf: String?,
+                paymentMethod: String?,
+                paymentMethodTypes: [String]?,
+                receiptEmail: String?,
+                savePaymentMethod: Bool?,
+                shipping: [String: Any]?,
+                source: String?,
+                statementDescriptor: String?,
+                transferData: [String: Any]?,
+                transferGroup: String?) -> Future<PaymentIntent>
+
+    /// Retrieves the details of a PaymentIntent that has previously been created.
+    ///
+    /// - Parameter id: The identifier of the paymentintent to be retrieved.
+    /// - Returns: A `StripePaymentIntent`.
+    func retrieve(id: String) -> Future<PaymentIntent>
+
+    /// Updates a PaymentIntent object.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the paymentintent to be updated.
+    ///   - amount: A positive integer representing how much to charge in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or equivalent in charge currency.
+    ///   - applicationFeeAmount: The amount of the application fee (if any) that will be applied to the payment and transferred to the application owner’s Stripe account. For more information, see the PaymentIntents Connect usage guide.
+    ///   - currency: Three-letter ISO currency code, in lowercase. Must be a supported currency.
+    ///   - customer: ID of the customer this PaymentIntent is for if one exists.
+    ///   - description: An arbitrary string attached to the object. Often useful for displaying to users. This will be unset if you POST an empty value.
+    ///   - metadata: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+    ///   - paymentMethod: ID of the payment method to attach to this PaymentIntent.
+    ///   - paymentMethodTypes: The list of payment method types that this PaymentIntent is allowed to use. If this is not provided, defaults to `[“card”]`. Valid payment method types include: `card` and `card_present`.
+    ///   - receiptEmail: Email address that the receipt for the resulting payment will be sent to.
+    ///   - savePaymentMethod: Set to `true` to save the PaymentIntent’s payment method (either `source` or `payment_method`) to the associated customer. If the payment method is already attached, this parameter does nothing. This parameter defaults to `false` and applies to the payment method passed in the same request or the current payment method attached to the PaymentIntent and must be specified again if a new payment method is added.
+    ///   - shipping: Shipping information for this PaymentIntent.
+    ///   - source: ID of the Source object to attach to this PaymentIntent.
+    ///   - statementDescriptor: Extra information about a PaymentIntent. This will appear on your customer’s statement when this PaymentIntent succeeds in creating a charge.
+    ///   - transferGroup: A string that identifies the resulting payment as part of a group. See the PaymentIntents Connect usage guide for details.
+    /// - Returns: A `StripePaymentIntent`.
+    func update(id: String,
+                amount: Int?,
+                applicationFeeAmount: Int?,
+                currency: StripeCurrency?,
+                customer: String?,
+                description: String?,
+                metadata: [String: String]?,
+                paymentMethod: String?,
+                paymentMethodTypes: [String]?,
+                receiptEmail: String?,
+                savePaymentMethod: Bool?,
+                shipping: [String: Any]?,
+                source: String?,
+                statementDescriptor: String?,
+                transferGroup: String?) -> Future<PaymentIntent>
+
+    /// Confirm that your customer intends to pay with current or provided payment method. Upon confirmation, the PaymentIntent will attempt to initiate a payment. /n If the selected payment method requires additional authentication steps, the PaymentIntent will transition to the `requires_action` status and suggest additional actions via `next_action`. If payment fails, the PaymentIntent will transition to the `requires_payment_method` status. If payment succeeds, the PaymentIntent will transition to the `succeeded` status (or `requires_capture`, if `capture_method` is set to `manual`). /n If the `confirmation_method` is `automatic`, payment may be attempted using our client SDKs and the PaymentIntent’s client_secret. After `next_action`s are handled by the client, no additional confirmation is required to complete the payment. /n If the `confirmation_method` is `manual`, all payment attempts must be initiated using a secret key. If any actions are required for the payment, the PaymentIntent will return to the `requires_confirmation` state after those actions are completed. Your server needs to then explicitly re-confirm the PaymentIntent to initiate the next payment attempt. Read the expanded documentation to learn more about manual confirmation.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the paymentintent to be confirmed.
+    ///   - paymentMethod: ID of the payment method to attach to this PaymentIntent.
+    ///   - receiptEmail: Email address that the receipt for the resulting payment will be sent to.
+    ///   - returnUrl: The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method’s app or site. If you’d prefer to redirect to a mobile application, you can alternatively supply an application URI scheme. This parameter is only used for cards and other redirect-based payment methods.
+    ///   - savePaymentMethod: Set to `true` to save the PaymentIntent’s payment method (either `source` or `payment_method`) to the associated customer. If the payment method is already attached, this parameter does nothing. This parameter defaults to `false` and applies to the payment method passed in the same request or the current payment method attached to the PaymentIntent and must be specified again if a new payment method is added.
+    ///   - shipping: Shipping information for this PaymentIntent.
+    ///   - source: ID of the Source object to attach to this PaymentIntent.
+    /// - Returns: A `StripePaymentIntent`.
+    func confirm(id: String,
+                 paymentMethod: String?,
+                 receiptEmail: String?,
+                 returnUrl: String?,
+                 savePaymentMethod: Bool?,
+                 shipping: [String: Any]?,
+                 source: String?) -> Future<PaymentIntent>
+
+    /// Capture the funds of an existing uncaptured PaymentIntent when its status is `requires_capture`. /n Uncaptured PaymentIntents will be canceled exactly seven days after they are created. /n Read the expanded documentation to learn more about separate authorization and capture.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the paymentintent to capture.
+    ///   - amountToCapture: The amount to capture from the PaymentIntent, which must be less than or equal to the original amount. Any additional amount will be automatically refunded. Defaults to the full `amount_capturable` if not provided.
+    ///   - applicationfeeAmount: The amount of the application fee (if any) that will be applied to the payment and transferred to the application owner’s Stripe account. For more information, see the PaymentIntents Connect usage guide.
+    /// - Returns: A `StripePaymentIntent`.
+    func capture(id: String, amountToCapture: Int?, applicationFeeAmount: Int?) -> Future<PaymentIntent>
+
+    ///  PaymentIntent object can be canceled when it is in one of these statuses: `requires_payment_method`, `requires_capture`, `requires_confirmation`, `requires_action`. /n Once canceled, no additional charges will be made by the PaymentIntent and any operations on the PaymentIntent will fail with an error. For PaymentIntents with `status='requires_capture'`, the remaining `amount_capturable` will automatically be refunded.
+    ///
+    /// - Parameters:
+    ///   - id: The identifier of the paymentintent to cancel.
+    ///   - cancellationReason: Reason for canceling this PaymentIntent. If set, possible values are `duplicate`, `fraudulent`, `requested_by_customer`, or `failed_invoice`
+    /// - Returns: A `StripePaymentIntent`.
+    func cancel(id: String, cancellationReason: PaymentIntentCancellationReason?) -> Future<PaymentIntent>
+
+    /// Returns a list of PaymentIntents.
+    ///
+    /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/payment_intents/list).
+    /// - Returns: A `StripePaymentIntentsList`.
+    func listAll(filter: [String: Any]?) -> Future<PaymentIntentsList>
+}
+
+extension PaymentIntentsRoutes {
+    public func create(amount: Int,
+                       currency: StripeCurrency,
+                       applicationFeeAmount: Int? = nil,
+                       captureMethod: PaymentIntentCaptureMethod? = nil,
+                       confirm: Bool? = nil,
+                       confirmationMethod: PaymentIntentConfirmationMethod? = nil,
+                       customer: String? = nil,
+                       description: String? = nil,
+                       metadata: [String: String]? = nil,
+                       onBehalfOf: String? = nil,
+                       paymentMethod: String? = nil,
+                       paymentMethodTypes: [String]? = nil,
+                       receiptEmail: String? = nil,
+                       savePaymentMethod: Bool? = nil,
+                       shipping: [String: Any]? = nil,
+                       source: String? = nil,
+                       statementDescriptor: String? = nil,
+                       transferData: [String: Any]? = nil,
+                       transferGroup: String? = nil) -> Future<PaymentIntent> {
+        return create(amount: amount,
+                          currency: currency,
+                          applicationFeeAmount: applicationFeeAmount,
+                          captureMethod: captureMethod,
+                          confirm: confirm,
+                          confirmationMethod: confirmationMethod,
+                          customer: customer,
+                          description: description,
+                          metadata: metadata,
+                          onBehalfOf: onBehalfOf,
+                          paymentMethod: paymentMethod,
+                          paymentMethodTypes: paymentMethodTypes,
+                          receiptEmail: receiptEmail,
+                          savePaymentMethod: savePaymentMethod,
+                          shipping: shipping,
+                          source: source,
+                          statementDescriptor: statementDescriptor,
+                          transferData: transferData,
+                          transferGroup: transferGroup)
+    }
+
+    public func retrieve(id: String) -> Future<PaymentIntent> {
+        return retrieve(id: id)
+    }
+
+    public func update(id: String,
+                       amount: Int? = nil,
+                       applicationFeeAmount: Int? = nil,
+                       currency: StripeCurrency? = nil,
+                       customer: String? = nil,
+                       description: String? = nil,
+                       metadata: [String: String]? = nil,
+                       paymentMethod: String? = nil,
+                       paymentMethodTypes: [String]? = nil,
+                       receiptEmail: String? = nil,
+                       savePaymentMethod: Bool? = nil,
+                       shipping: [String: Any]? = nil,
+                       source: String? = nil,
+                       statementDescriptor: String? = nil,
+                       transferGroup: String? = nil) -> Future<PaymentIntent> {
+        return update(id: id,
+                          amount: amount,
+                          applicationFeeAmount: applicationFeeAmount,
+                          currency: currency,
+                          customer: customer,
+                          description: description,
+                          metadata: metadata,
+                          paymentMethod: paymentMethod,
+                          paymentMethodTypes: paymentMethodTypes,
+                          receiptEmail: receiptEmail,
+                          savePaymentMethod: savePaymentMethod,
+                          shipping: shipping,
+                          source: source,
+                          statementDescriptor: statementDescriptor,
+                          transferGroup: transferGroup)
+    }
+
+    public func confirm(id: String,
+                        paymentMethod: String? = nil,
+                        receiptEmail: String? = nil,
+                        returnUrl: String? = nil,
+                        savePaymentMethod: Bool? = nil,
+                        shipping: [String: Any]? = nil,
+                        source: String? = nil) -> Future<PaymentIntent> {
+        return confirm(id: id,
+                           paymentMethod: paymentMethod,
+                           receiptEmail: receiptEmail,
+                           returnUrl: returnUrl,
+                           savePaymentMethod: savePaymentMethod,
+                           shipping: shipping,
+                           source: source)
+    }
+
+    public func capture(id: String, amountToCapture: Int? = nil, applicationFeeAmount: Int? = nil) -> Future<PaymentIntent> {
+        return capture(id: id, amountToCapture: amountToCapture, applicationFeeAmount: applicationFeeAmount)
+    }
+
+    public func cancel(id: String, cancellationReason: PaymentIntentCancellationReason? = nil) -> Future<PaymentIntent> {
+        return cancel(id: id, cancellationReason: cancellationReason)
+    }
+
+    public func listAll(filter: [String: Any]? = nil) -> Future<PaymentIntentsList> {
+        return listAll(filter: filter)
+    }
+}
+
+public struct StripePaymentIntentsRoutes: PaymentIntentsRoutes {
+    private let request: StripeRequest
+
+    init(request: StripeRequest) {
+        self.request = request
+    }
+
+    public func create(amount: Int,
+                       currency: StripeCurrency,
+                       applicationFeeAmount: Int?,
+                       captureMethod: PaymentIntentCaptureMethod?,
+                       confirm: Bool?,
+                       confirmationMethod: PaymentIntentConfirmationMethod?,
+                       customer: String?,
+                       description: String?,
+                       metadata: [String: String]?,
+                       onBehalfOf: String?,
+                       paymentMethod: String?,
+                       paymentMethodTypes: [String]?,
+                       receiptEmail: String?,
+                       savePaymentMethod: Bool?,
+                       shipping: [String: Any]?,
+                       source: String?,
+                       statementDescriptor: String?,
+                       transferData: [String: Any]?,
+                       transferGroup: String?) throws -> Future<PaymentIntent> {
+        var body: [String: Any] = ["amount": amount,
+                                   "currency": currency.rawValue]
+
+        if let applicationfeeAmount = applicationFeeAmount {
+            body["application_fee_amount"] = applicationfeeAmount
+        }
+
+        if let captureMethod = captureMethod {
+            body["capture_method"] = captureMethod.rawValue
+        }
+
+        if let confirm = confirm {
+            body["confirm"] = confirm
+        }
+
+        if let confirmationMethod = confirmationMethod {
+            body["confirmation_method"] = confirmationMethod.rawValue
+        }
+
+        if let customer = customer {
+            body["customer"] = customer
+        }
+
+        if let description = description {
+            body["description"] = description
+        }
+
+        if let metadata = metadata {
+            metadata.forEach { body["metadata[\($0)]"] = $1 }
+        }
+
+        if let onBehalfOf = onBehalfOf {
+            body["on_behalf_of"] = onBehalfOf
+        }
+
+        if let paymentMethod = paymentMethod {
+            body["payment_method"] = paymentMethod
+        }
+
+        if let paymentMethodTypes = paymentMethodTypes {
+            body["payment_method_types"] = paymentMethodTypes
+        }
+
+        if let receiptEmail = receiptEmail {
+            body["receipt_email"] = receiptEmail
+        }
+
+        if let savePaymentMethod = savePaymentMethod {
+            body["save_payment_method"] = savePaymentMethod
+        }
+
+        if let shipping = shipping {
+            shipping.forEach { body["shipping[\($0)]"] = $1 }
+        }
+
+        if let source = source {
+            body["source"] = source
+        }
+
+        if let statementDescriptor = statementDescriptor {
+            body["statement_descriptor"] = statementDescriptor
+        }
+
+        if let transferData = transferData {
+            transferData.forEach { body["transfer_data[\($0)]"] = $1 }
+        }
+
+        if let transferGroup = transferGroup {
+            body["transfer_group"] = transferGroup
+        }
+
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntents.endpoint,
+                                body: body.queryParameters)
+    }
+
+    public func retrieve(id: String) throws -> Future<PaymentIntent> {
+        return try request.send(method: .GET, path: StripeAPIEndpoint.paymentIntent(id).endpoint)
+    }
+
+    public func update(id: String,
+                       amount: Int?,
+                       applicationFeeAmount: Int?,
+                       currency: StripeCurrency?,
+                       customer: String?,
+                       description: String?,
+                       metadata: [String: String]?,
+                       paymentMethod: String?,
+                       paymentMethodTypes: [String]?,
+                       receiptEmail: String?,
+                       savePaymentMethod: Bool?,
+                       shipping: [String: Any]?,
+                       source: String?,
+                       statementDescriptor: String?,
+                       transferGroup: String?) throws -> Future<PaymentIntent> {
+        var body: [String: Any] = [:]
+
+        if let amount = amount {
+            body["amount"] = amount
+        }
+
+        if let applicationfeeAmount = applicationFeeAmount {
+            body["application_fee_amount"] = applicationfeeAmount
+        }
+
+        if let customer = customer {
+            body["customer"] = customer
+        }
+
+        if let description = description {
+            body["description"] = description
+        }
+
+        if let metadata = metadata {
+            metadata.forEach { body["metadata[\($0)]"] = $1 }
+        }
+
+        if let paymentMethod = paymentMethod {
+            body["payment_method"] = paymentMethod
+        }
+
+        if let paymentMethodTypes = paymentMethodTypes {
+            body["payment_method_types"] = paymentMethodTypes
+        }
+
+        if let receiptEmail = receiptEmail {
+            body["receipt_email"] = receiptEmail
+        }
+
+        if let savePaymentMethod = savePaymentMethod {
+            body["save_payment_method"] = savePaymentMethod
+        }
+
+        if let shipping = shipping {
+            shipping.forEach { body["shipping[\($0)]"] = $1 }
+        }
+
+        if let source = source {
+            body["source"] = source
+        }
+
+        if let statementDescriptor = statementDescriptor {
+            body["statement_descriptor"] = statementDescriptor
+        }
+
+        if let transferGroup = transferGroup {
+            body["transfer_group"] = transferGroup
+        }
+
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntent(id).endpoint,
+                                body: body.queryParameters)
+    }
+
+    public func confirm(id: String,
+                        paymentMethod: String?,
+                        receiptEmail: String?,
+                        returnUrl: String?,
+                        savePaymentMethod: Bool?,
+                        shipping: [String: Any]?,
+                        source: String?) throws -> Future<PaymentIntent> {
+        var body: [String: Any] = [:]
+
+        if let paymentMethod = paymentMethod {
+            body["payment_method"] = paymentMethod
+        }
+
+        if let receiptEmail = receiptEmail {
+            body["receipt_email"] = receiptEmail
+        }
+
+        if let returnUrl = returnUrl {
+            body["return_url"] = returnUrl
+        }
+
+        if let savePaymentMethod = savePaymentMethod {
+            body["save_payment_method"] = savePaymentMethod
+        }
+
+        if let shipping = shipping {
+            shipping.forEach { body["shipping[\($0)]"] = $1 }
+        }
+
+        if let source = source {
+            body["source"] = source
+        }
+
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntentConfirm(id).endpoint,
+                                body: body.queryParameters)
+    }
+
+    public func capture(id: String, amountToCapture: Int?, applicationFeeAmount: Int?) throws -> Future<PaymentIntent> {
+        var body: [String: Any] = [:]
+
+        if let amountToCapture = amountToCapture {
+            body["amount_to_capture"] = amountToCapture
+        }
+
+        if let applicationFeeAmount = applicationFeeAmount {
+            body["application_fee_amount"] = applicationFeeAmount
+        }
+
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntentCapture(id).endpoint,
+                                body: body.queryParameters)
+    }
+
+    public func cancel(id: String, cancellationReason: PaymentIntentCancellationReason?) throws -> Future<PaymentIntent> {
+        var body: [String: Any] = [:]
+
+        if let cancellationReason = cancellationReason {
+            body["cancellation_reason"] = cancellationReason.rawValue
+        }
+
+        return try request.send(method: .POST, path: StripeAPIEndpoint.paymentIntentCancel(id).endpoint,
+                                body: body.queryParameters)
+    }
+
+    public func listAll(filter: [String: Any]?) throws -> Future<PaymentIntentsList> {
+        var queryParams = ""
+        if let filter = filter {
+            queryParams = filter.queryParameters
+        }
+
+        return try request.send(method: .GET, path: StripeAPIEndpoint.paymentIntents.endpoint, query: queryParams)
+    }
+}
+

--- a/Sources/Stripe/API/Routes/PaymentIntentRoutes.swift
+++ b/Sources/Stripe/API/Routes/PaymentIntentRoutes.swift
@@ -49,13 +49,13 @@ public protocol PaymentIntentsRoutes {
                 source: String?,
                 statementDescriptor: String?,
                 transferData: [String: Any]?,
-                transferGroup: String?) -> Future<PaymentIntent>
+                transferGroup: String?) throws -> Future<PaymentIntent>
 
     /// Retrieves the details of a PaymentIntent that has previously been created.
     ///
     /// - Parameter id: The identifier of the paymentintent to be retrieved.
     /// - Returns: A `StripePaymentIntent`.
-    func retrieve(id: String) -> Future<PaymentIntent>
+    func retrieve(id: String) throws -> Future<PaymentIntent>
 
     /// Updates a PaymentIntent object.
     ///
@@ -90,7 +90,7 @@ public protocol PaymentIntentsRoutes {
                 shipping: [String: Any]?,
                 source: String?,
                 statementDescriptor: String?,
-                transferGroup: String?) -> Future<PaymentIntent>
+                transferGroup: String?) throws -> Future<PaymentIntent>
 
     /// Confirm that your customer intends to pay with current or provided payment method. Upon confirmation, the PaymentIntent will attempt to initiate a payment. /n If the selected payment method requires additional authentication steps, the PaymentIntent will transition to the `requires_action` status and suggest additional actions via `next_action`. If payment fails, the PaymentIntent will transition to the `requires_payment_method` status. If payment succeeds, the PaymentIntent will transition to the `succeeded` status (or `requires_capture`, if `capture_method` is set to `manual`). /n If the `confirmation_method` is `automatic`, payment may be attempted using our client SDKs and the PaymentIntent’s client_secret. After `next_action`s are handled by the client, no additional confirmation is required to complete the payment. /n If the `confirmation_method` is `manual`, all payment attempts must be initiated using a secret key. If any actions are required for the payment, the PaymentIntent will return to the `requires_confirmation` state after those actions are completed. Your server needs to then explicitly re-confirm the PaymentIntent to initiate the next payment attempt. Read the expanded documentation to learn more about manual confirmation.
     ///
@@ -109,7 +109,7 @@ public protocol PaymentIntentsRoutes {
                  returnUrl: String?,
                  savePaymentMethod: Bool?,
                  shipping: [String: Any]?,
-                 source: String?) -> Future<PaymentIntent>
+                 source: String?) throws -> Future<PaymentIntent>
 
     /// Capture the funds of an existing uncaptured PaymentIntent when its status is `requires_capture`. /n Uncaptured PaymentIntents will be canceled exactly seven days after they are created. /n Read the expanded documentation to learn more about separate authorization and capture.
     ///
@@ -118,7 +118,7 @@ public protocol PaymentIntentsRoutes {
     ///   - amountToCapture: The amount to capture from the PaymentIntent, which must be less than or equal to the original amount. Any additional amount will be automatically refunded. Defaults to the full `amount_capturable` if not provided.
     ///   - applicationfeeAmount: The amount of the application fee (if any) that will be applied to the payment and transferred to the application owner’s Stripe account. For more information, see the PaymentIntents Connect usage guide.
     /// - Returns: A `StripePaymentIntent`.
-    func capture(id: String, amountToCapture: Int?, applicationFeeAmount: Int?) -> Future<PaymentIntent>
+    func capture(id: String, amountToCapture: Int?, applicationFeeAmount: Int?) throws -> Future<PaymentIntent>
 
     ///  PaymentIntent object can be canceled when it is in one of these statuses: `requires_payment_method`, `requires_capture`, `requires_confirmation`, `requires_action`. /n Once canceled, no additional charges will be made by the PaymentIntent and any operations on the PaymentIntent will fail with an error. For PaymentIntents with `status='requires_capture'`, the remaining `amount_capturable` will automatically be refunded.
     ///
@@ -126,13 +126,13 @@ public protocol PaymentIntentsRoutes {
     ///   - id: The identifier of the paymentintent to cancel.
     ///   - cancellationReason: Reason for canceling this PaymentIntent. If set, possible values are `duplicate`, `fraudulent`, `requested_by_customer`, or `failed_invoice`
     /// - Returns: A `StripePaymentIntent`.
-    func cancel(id: String, cancellationReason: PaymentIntentCancellationReason?) -> Future<PaymentIntent>
+    func cancel(id: String, cancellationReason: PaymentIntentCancellationReason?) throws -> Future<PaymentIntent>
 
     /// Returns a list of PaymentIntents.
     ///
     /// - Parameter filter: A dictionary that contains the filters. More info [here](https://stripe.com/docs/api/payment_intents/list).
     /// - Returns: A `StripePaymentIntentsList`.
-    func listAll(filter: [String: Any]?) -> Future<PaymentIntentsList>
+    func listAll(filter: [String: Any]?) throws -> Future<PaymentIntentsList>
 }
 
 extension PaymentIntentsRoutes {
@@ -154,8 +154,8 @@ extension PaymentIntentsRoutes {
                        source: String? = nil,
                        statementDescriptor: String? = nil,
                        transferData: [String: Any]? = nil,
-                       transferGroup: String? = nil) -> Future<PaymentIntent> {
-        return create(amount: amount,
+                       transferGroup: String? = nil) throws -> Future<PaymentIntent> {
+        return try create(amount: amount,
                           currency: currency,
                           applicationFeeAmount: applicationFeeAmount,
                           captureMethod: captureMethod,
@@ -176,8 +176,8 @@ extension PaymentIntentsRoutes {
                           transferGroup: transferGroup)
     }
 
-    public func retrieve(id: String) -> Future<PaymentIntent> {
-        return retrieve(id: id)
+    public func retrieve(id: String) throws -> Future<PaymentIntent> {
+        return try retrieve(id: id)
     }
 
     public func update(id: String,
@@ -194,8 +194,8 @@ extension PaymentIntentsRoutes {
                        shipping: [String: Any]? = nil,
                        source: String? = nil,
                        statementDescriptor: String? = nil,
-                       transferGroup: String? = nil) -> Future<PaymentIntent> {
-        return update(id: id,
+                       transferGroup: String? = nil) throws -> Future<PaymentIntent> {
+        return try update(id: id,
                           amount: amount,
                           applicationFeeAmount: applicationFeeAmount,
                           currency: currency,
@@ -218,8 +218,8 @@ extension PaymentIntentsRoutes {
                         returnUrl: String? = nil,
                         savePaymentMethod: Bool? = nil,
                         shipping: [String: Any]? = nil,
-                        source: String? = nil) -> Future<PaymentIntent> {
-        return confirm(id: id,
+                        source: String? = nil) throws -> Future<PaymentIntent> {
+        return try confirm(id: id,
                            paymentMethod: paymentMethod,
                            receiptEmail: receiptEmail,
                            returnUrl: returnUrl,
@@ -228,16 +228,16 @@ extension PaymentIntentsRoutes {
                            source: source)
     }
 
-    public func capture(id: String, amountToCapture: Int? = nil, applicationFeeAmount: Int? = nil) -> Future<PaymentIntent> {
-        return capture(id: id, amountToCapture: amountToCapture, applicationFeeAmount: applicationFeeAmount)
+    public func capture(id: String, amountToCapture: Int? = nil, applicationFeeAmount: Int? = nil) throws -> Future<PaymentIntent> {
+        return try capture(id: id, amountToCapture: amountToCapture, applicationFeeAmount: applicationFeeAmount)
     }
 
-    public func cancel(id: String, cancellationReason: PaymentIntentCancellationReason? = nil) -> Future<PaymentIntent> {
-        return cancel(id: id, cancellationReason: cancellationReason)
+    public func cancel(id: String, cancellationReason: PaymentIntentCancellationReason? = nil) throws -> Future<PaymentIntent> {
+        return try cancel(id: id, cancellationReason: cancellationReason)
     }
 
-    public func listAll(filter: [String: Any]? = nil) -> Future<PaymentIntentsList> {
-        return listAll(filter: filter)
+    public func listAll(filter: [String: Any]? = nil) throws -> Future<PaymentIntentsList> {
+        return try listAll(filter: filter)
     }
 }
 

--- a/Sources/Stripe/API/StripeRequest.swift
+++ b/Sources/Stripe/API/StripeRequest.swift
@@ -46,7 +46,7 @@ extension HTTPHeaderName {
 extension HTTPHeaders {
     public static var stripeDefault: HTTPHeaders {
         var headers: HTTPHeaders = [:]
-        headers.replaceOrAdd(name: .stripeVersion, value: "2019-02-19")
+        headers.replaceOrAdd(name: .stripeVersion, value: "2019-09-09")
         headers.replaceOrAdd(name: .contentType, value: MediaType.urlEncodedForm.description)
         return headers
     }

--- a/Sources/Stripe/Models/Connect/Account.swift
+++ b/Sources/Stripe/Models/Connect/Account.swift
@@ -89,7 +89,7 @@ public struct StripeConnectAccountCapablities: StripeModel {
     private enum CodingKeys: String, CodingKey {
         case cardPayments = "card_payments"
         case legacyPayments = "legacy_payments"
-        case platformPayments = "platform_payments"
+        case platformPayments = "transfers"
     }
 }
 

--- a/Sources/Stripe/Models/Invoices/Invoice.swift
+++ b/Sources/Stripe/Models/Invoices/Invoice.swift
@@ -29,13 +29,12 @@ public struct StripeInvoice: StripeModel {
     public var closed: Bool?
     public var currency: StripeCurrency?
     public var customer: String?
-    public var date: Date?
+    public var created: Date?
     public var defaultSource: String?
     public var description: String?
     public var discount: StripeDiscount?
     public var dueDate: Date?
     public var endingBalance: Int?
-    public var finalizedAt: Date?
     public var forgiven: Bool?
     public var hostedInvoiceUrl: String?
     public var invoicePdf: String?
@@ -51,6 +50,7 @@ public struct StripeInvoice: StripeModel {
     public var startingBalance: Int?
     public var statementDescriptor: String?
     public var status: StripeInvoiceStatus?
+    public var statusTransitions: StripeInvoiceStatusTransitions?
     public var subscription: String?
     public var subscriptionProrationDate: Int?
     public var subtotal: Int?
@@ -65,7 +65,7 @@ public struct StripeInvoice: StripeModel {
         case amountDue = "amount_due"
         case amountPaid = "amount_paid"
         case amountRemanining = "amount_remaining"
-        case applicationFee = "application_fee"
+        case applicationFee = "application_fee_amount"
         case attemptCount = "attempt_count"
         case attempted
         case autoAdvance = "auto_advance"
@@ -75,13 +75,12 @@ public struct StripeInvoice: StripeModel {
         case closed
         case currency
         case customer
-        case date
+        case created
         case defaultSource = "default_source"
         case description
         case discount
         case dueDate = "due_date"
         case endingBalance = "ending_balance"
-        case finalizedAt = "finalized_at"
         case forgiven
         case hostedInvoiceUrl = "hosted_invoice_url"
         case invoicePdf = "invoice_pdf"
@@ -97,6 +96,7 @@ public struct StripeInvoice: StripeModel {
         case startingBalance = "starting_balance"
         case statementDescriptor = "statement_descriptor"
         case status
+        case statusTransitions = "status_transitions"
         case subscription
         case subscriptionProrationDate = "subscription_proration_date"
         case subtotal

--- a/Sources/Stripe/Models/Invoices/InvoiceStatusTransitions.swift
+++ b/Sources/Stripe/Models/Invoices/InvoiceStatusTransitions.swift
@@ -1,0 +1,26 @@
+//
+//  InvoiceStatusTransitions.swift
+//  Stripe
+//
+//  Created by Kristian Andersen on 08/10/2019.
+//
+
+import Foundation
+
+public struct StripeInvoiceStatusTransitions: StripeModel {
+    /// The time that the invoice draft was finalized.
+    public var finalizedAt: Date?
+    /// The time that the invoice was marked uncollectible.
+    public var markedUncollectableAt: Date?
+    /// The time that the invoice was paid.
+    public var paidAt: Date?
+    /// The time that the invoice was voided.
+    public var voidedAt: Date?
+
+    public enum CodingKeys: String, CodingKey {
+        case finalizedAt = "finalized_at"
+        case markedUncollectableAt = "marked_uncollectable_at"
+        case paidAt = "paid_at"
+        case voidedAt = "voided_at"
+    }
+}

--- a/Sources/Stripe/Models/PaymentIntents/PaymentIntent.swift
+++ b/Sources/Stripe/Models/PaymentIntents/PaymentIntent.swift
@@ -1,0 +1,187 @@
+//
+//  PaymentIntent.swift
+//  Stripe
+//
+//  Created by Kristian Andersen on 08/10/2019.
+//
+
+import Foundation
+
+/// The [PaymentIntent Object](https://stripe.com/docs/api/payment_intents/object).
+public struct PaymentIntent: StripeModel {
+    /// Unique identifier for the object.
+    public var id: String
+    /// String representing the object’s type. Objects of the same type share the same value.
+    public var object: String
+    /// Amount intended to be collected by this PaymentIntent.
+    public var amount: Int?
+    /// Amount that can be captured from this PaymentIntent.
+    public var amountCapturable: Int?
+    /// Amount that was collected by this PaymentIntent.
+    public var amountReceived: Int?
+    /// ID of the Connect application that created the PaymentIntent.
+    public var application: String?
+    /// The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [Connect usage guide](https://stripe.com/docs/payments/payment-intents/usage#connect) for details.
+    public var applicationFeeAmount: Int?
+    /// Populated when `status` is `canceled`, this is the time at which the PaymentIntent was canceled. Measured in seconds since the Unix epoch.
+    public var canceledAt: Date?
+    /// User-given reason for cancellation of this PaymentIntent, one of `duplicate`, `fraudulent`, `requested_by_customer`, or `failed_invoice`.
+    public var cancellationReason: PaymentIntentCancellationReason?
+    /// Capture method of this PaymentIntent, one of `automatic` or `manual`.
+    public var captureMethod: PaymentIntentCaptureMethod?
+    /// Charges that were created by this PaymentIntent, if any.
+    public var charges: ChargesList?
+    /// The client secret of this PaymentIntent. Used for client-side retrieval using a publishable key. Please refer to [dynamic authentication](https://stripe.com/docs/payments/dynamic-authentication) guide on how `client_secret` should be handled.
+    public var clientSecret: String?
+    /// Confirmation method of this PaymentIntent, one of `manual` or `automatic`.
+    public var confirmationMethod: PaymentIntentConfirmationMethod?
+    /// Time at which the object was created. Measured in seconds since the Unix epoch.
+    public var created: Date?
+    /// Three-letter ISO currency code, in lowercase. Must be a supported currency.
+    public var currency: StripeCurrency?
+    /// ID of the Customer this PaymentIntent is for if one exists.
+    public var customer: String?
+    /// An arbitrary string attached to the object. Often useful for displaying to users.
+    public var description: String?
+    /// ID of the invoice that created this PaymentIntent, if it exists.
+    public var invoice: String?
+    /// The payment error encountered in the previous PaymentIntent confirmation.
+    public var lastPaymentError: StripeError?
+    /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+    public var livemode: Bool?
+    /// Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+    public var metadata: [String: String]?
+    /// If present, this property tells you what actions you need to take in order for your customer to fulfill a payment using the provided source.
+    public var StripePaymentIntentNextAction: String?
+    /// The account (if any) for which the funds of the PaymentIntent are intended. See the PaymentIntents Connect usage guide for details.
+    public var onBehalfOn: String?
+    /// ID of the payment method used in this PaymentIntent.
+    public var paymentMethod: String?
+    /// The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
+    public var paymentMethodTypes: [String]?
+    /// Email address that the receipt for the resulting payment will be sent to.
+    public var receiptEmail: String?
+    /// ID of the review associated with this PaymentIntent, if any.
+    public var review: String?
+    /// Indicates that you intend to make future payments with this PaymentIntent’s payment method.
+    /// If present, the payment method used with this PaymentIntent can be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the transaction completes
+    ///
+    /// Use `on_session` if you intend to only reuse the payment method when your customer is present in your checkout flow. Use `off_session` if your customer may or may not be in your checkout flow. See [Saving card details after a payment](https://stripe.com/docs/payments/cards/saving-cards#saving-card-after-payment) to learn more.
+    ///
+    /// Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules. For example, if your customer is impacted by [SCA](https://stripe.com/docs/strong-customer-authentication), using off_session will ensure that they are authenticated while processing this PaymentIntent. You will then be able to collect [off-session payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards) for this customer.
+    public var setupFutureUsage: String?
+    /// Shipping information for this PaymentIntent.
+    public var shipping: ShippingLabel?
+    /// ID of the source used in this PaymentIntent.
+    public var source: String?
+    /// Extra information about a PaymentIntent. This will appear on your customer’s statement when this PaymentIntent succeeds in creating a charge.
+    public var statementDescriptor: String?
+    /// Status of this PaymentIntent, one of `requires_payment_method`, `requires_confirmation`, `requires_action`, `processing`, `requires_capture`, `canceled`, or `succeeded`.
+    public var status: PaymentIntentStatus?
+    /// The data with which to automatically create a Transfer when the payment is finalized. See the PaymentIntents Connect usage guide for details.
+    public var transferData: [String: String]?
+    /// A string that identifies the resulting payment as part of a group. See the PaymentIntents Connect usage guide for details.
+    public var transferGroup: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case amount
+        case amountCapturable = "amount_capturable"
+        case amountReceived = "amount_received"
+        case application
+        case applicationFeeAmount = "application_fee_amount"
+        case canceledAt = "canceled_at"
+        case cancellationReason = "cancellation_reason"
+        case captureMethod = "capture_method"
+        case charges
+        case clientSecret = "client_secret"
+        case confirmationMethod = "confirmation_method"
+        case created
+        case currency
+        case customer
+        case description
+        case invoice
+        case lastPaymentError = "last_payment_error"
+        case livemode
+        case metadata
+        case StripePaymentIntentNextAction = "next_action"
+        case onBehalfOn = "on_behalf_of"
+        case paymentMethod = "payment_method"
+        case paymentMethodTypes = "payment_method_types"
+        case receiptEmail = "receipt_email"
+        case review
+        case setupFutureUsage = "setup_future_usage"
+        case shipping
+        case source
+        case statementDescriptor = "statement_descriptor"
+        case status
+        case transferData = "transfer_data"
+        case transferGroup = "transfer_group"
+    }
+}
+
+public enum PaymentIntentCancellationReason: String, StripeModel {
+    case duplicate
+    case fraudulent
+    case requestedByCustomer = "requested_by_customer"
+    case failedInvoice = "failed_invoice"
+}
+
+public enum PaymentIntentCaptureMethod: String, StripeModel {
+    case automatic
+    case manual
+}
+
+public enum PaymentIntentConfirmationMethod: String, StripeModel {
+    case automatic
+    case manual
+}
+
+public struct PaymentIntentNextAction: StripeModel {
+    /// Contains instructions for authenticating a payment by redirecting your customer to another page or application.
+    public var redirectToUrl: PaymentIntentNextActionRedirectToUrl?
+    /// Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`.
+    public var type: PaymentIntentNextActionType?
+}
+
+public struct PaymentIntentNextActionRedirectToUrl: StripeModel {
+    /// If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
+    public var returnUrl: String?
+    /// The URL you must redirect your customer to in order to authenticate the payment.
+    public var url: String?
+    /**
+     https://stripe.com/docs/api/payment_intents/object#payment_intent_object-next_action-use_stripe_sdk
+     Stripe .net doesn't implement the `use_stripe_sdk` property (probably due to its dynamic nature) so neither am I :)
+     https://github.com/stripe/stripe-dotnet/blob/master/src/Stripe.net/Entities/PaymentIntents/PaymentIntentNextAction.cs
+     */
+}
+
+public enum PaymentIntentNextActionType: String, StripeModel {
+    case redirectToUrl = "redirect_to_url"
+    case useStripeSDK = "use_stripe_sdk"
+}
+
+public enum PaymentIntentStatus: String, StripeModel {
+    case requiresPaymentMethod = "requires_payment_method"
+    case requiresConfirmation = "requires_confirmation"
+    case requiresAction = "requires_action"
+    case processing
+    case requiresCapture = "requires_capture"
+    case canceled
+    case succeeded
+}
+
+public struct PaymentIntentsList: StripeModel {
+    public var object: String
+    public var hasMore: Bool?
+    public var url: String?
+    public var data: [PaymentIntent]?
+
+    public enum CodingKeys: String, CodingKey {
+        case object
+        case hasMore = "has_more"
+        case url
+        case data
+    }
+}

--- a/Sources/Stripe/Provider/Provider.swift
+++ b/Sources/Stripe/Provider/Provider.swift
@@ -69,6 +69,7 @@ public final class StripeClient: Service {
     public var fileLinks: FileLinkRoutes
     public var files: FileRoutes
     public var person: PersonRoutes
+    public var paymentIntents: PaymentIntentsRoutes
 
     internal init(apiKey: String, testKey: String?, client: Client) {
         let apiRequest = StripeAPIRequest(httpClient: client, apiKey: apiKey, testApiKey: testKey)
@@ -98,5 +99,6 @@ public final class StripeClient: Service {
         fileLinks = StripeFileLinkRoutes(request: apiRequest)
         files = StripeFileRoutes(request: apiRequest)
         person = StripePersonRoutes(request: apiRequest)
+        paymentIntents = StripePaymentIntentsRoutes(request: apiRequest)
     }
 }

--- a/Tests/StripeTests/AccountTests.swift
+++ b/Tests/StripeTests/AccountTests.swift
@@ -35,7 +35,7 @@ class AccountTests: XCTestCase {
   "business_type": "individual",
   "capabilities": {
     "card_payments": "active",
-    "platform_payments": "inactive"
+    "transfers": "inactive"
   },
   "charges_enabled": false,
   "company": {

--- a/Tests/StripeTests/InvoiceTests.swift
+++ b/Tests/StripeTests/InvoiceTests.swift
@@ -24,10 +24,9 @@ class InvoiceTests: XCTestCase {
     "closed": false,
     "currency": "usd",
     "customer": "cus_CCiTI4Tpghl0nK",
-    "date": 1234567890,
+    "created": 1234567890,
     "default_source": null,
     "due_date": 1234567890,
-    "finalized_at": 1234567890,
     "forgiven": false,
     "hosted_invoice_url": "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT",
     "invoice_pdf": "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT/pdf",
@@ -68,6 +67,9 @@ class InvoiceTests: XCTestCase {
     "period_start": 1234567890,
     "starting_balance": 0,
     "status": "open",
+    "status_transitions": {
+        "finalized_at": 1234567890,
+    },
     "subtotal": 0,
     "total": 0,
     "webhooks_delivered_at": 1234567890
@@ -98,10 +100,10 @@ class InvoiceTests: XCTestCase {
                 XCTAssertEqual(invoice.closed, false)
                 XCTAssertEqual(invoice.currency, .usd)
                 XCTAssertEqual(invoice.customer, "cus_CCiTI4Tpghl0nK")
-                XCTAssertEqual(invoice.date, Date(timeIntervalSince1970: 1234567890))
+                XCTAssertEqual(invoice.created, Date(timeIntervalSince1970: 1234567890))
                 XCTAssertEqual(invoice.defaultSource, nil)
                 XCTAssertEqual(invoice.dueDate, Date(timeIntervalSince1970: 1234567890))
-                XCTAssertEqual(invoice.finalizedAt, Date(timeIntervalSince1970: 1234567890))
+                XCTAssertEqual(invoice.statusTransitions?.finalizedAt, Date(timeIntervalSince1970: 1234567890))
                 XCTAssertEqual(invoice.forgiven, false)
                 XCTAssertEqual(invoice.hostedInvoiceUrl, "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT")
                 XCTAssertEqual(invoice.invoicePdf, "https://pay.stripe.com/invoice/invst_zw7Gf743ihdarScjrVuMTtctoT/pdf")


### PR DESCRIPTION
The actual request was never created due to an infinite loop produced by repeatedly calling the incorrect method.