### PR TITLE
Add signature verification helper to Request

### DIFF
--- a/Sources/Stripe/Stripe+Extensions.swift
+++ b/Sources/Stripe/Stripe+Extensions.swift
@@ -41,7 +41,6 @@ extension Request {
 
 extension StripeClient {
     public static func verifySignature(for req: Request, secret: String, tolerance: Double = 300) throws {
-        
         guard let header = req.headers.first(name: "Stripe-Signature") else {
             throw StripeSignatureError.unableToParseHeader
         }

--- a/Sources/Stripe/Stripe+Extensions.swift
+++ b/Sources/Stripe/Stripe+Extensions.swift
@@ -40,6 +40,12 @@ extension Request {
 }
 
 extension StripeClient {
+    /// Verifies a Stripe signature for a given `Request`. This automatically looks for the header in the headers of the request and the body.
+    /// - Parameters:
+    ///     - req: The `Request` object to check header and body for
+    ///     - secret: The webhook secret used to verify the signature
+    ///     - tolerance: In seconds the time difference tolerance to prevent replay attacks: Default 300 seconds
+    /// - Throws: `StripeSignatureError`
     public static func verifySignature(for req: Request, secret: String, tolerance: Double = 300) throws {
         guard let header = req.headers.first(name: "Stripe-Signature") else {
             throw StripeSignatureError.unableToParseHeader


### PR DESCRIPTION
* Adds a helper method to verify a signature for a `Request`.
* Makes `StripeSignatureError` conform to `AbortError` for useful messages inside the Stripe logs.